### PR TITLE
feat(downloads): add persistent history ui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,16 +1523,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,7 +1699,6 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,10 +117,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -497,7 +555,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -566,13 +624,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.4.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -599,8 +690,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -613,17 +704,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.32",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "hyper 1.10.1",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -875,6 +1001,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maud"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
+dependencies = [
+ "axum-core",
+ "http 1.4.1",
+ "itoa",
+ "maud_macros",
+]
+
+[[package]]
+name = "maud_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1196,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,9 +1280,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -1128,7 +1296,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls",
@@ -1315,6 +1483,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1521,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -1380,10 +1569,12 @@ name = "splittarr"
 version = "0.2.6"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "clap",
  "config",
  "directories",
+ "maud",
  "rcue",
  "regex",
  "reqwest",
@@ -1393,6 +1584,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tower",
  "uuid",
  "walkdir",
 ]
@@ -1425,6 +1617,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -1511,6 +1709,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -1560,6 +1759,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1792,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.85"
 thiserror = "1"
-tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread", "time", "net", "io-util", "signal"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread", "time", "net", "io-util"] }
 uuid = { version = "1.1.2", features=["v4"] }
 walkdir = "2.3.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ codegen-units = 1
 
 [dependencies]
 anyhow = "1"
+axum = "0.8"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 config = "0.13.1"
 directories = "4.0.1"
+maud = { version = "0.27", features = ["axum"] }
 rcue = "0.1.3"
 regex = "1"
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls"] }
@@ -32,9 +34,10 @@ rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.85"
 thiserror = "1"
-tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread", "time", "net", "io-util"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread", "time", "net", "io-util", "signal"] }
 uuid = { version = "1.1.2", features=["v4"] }
 walkdir = "2.3.2"
 
 [dev-dependencies]
 tempfile = "3"
+tower = "0.5"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Splittarr is a small companion service for [Lidarr](https://lidarr.audio/) that handles albums delivered as a single audio file plus one or more CUE sheets.
 
-Lidarr usually expects individual track files. When a single-file album fails to import, Splittarr detects that failed queue item, finds the CUE file, splits the referenced audio into FLAC tracks with `shnsplit`, records the files it created, and then removes only those generated files after Lidarr has imported them.
+Lidarr usually expects individual track files. When a single-file album fails to import, Splittarr detects that failed queue item, finds the CUE file, splits the referenced audio into FLAC tracks with `shnsplit`, records the full processing history in SQLite, and removes only those generated files after Lidarr has imported them.
 
 ## What it does
 
@@ -19,10 +19,11 @@ For each matching download, Splittarr:
 2. parses each CUE file
 3. checks that the CUE file references an audio file in the same directory
 4. runs `shnsplit` in that directory
-5. stores the generated track paths in a SQLite database
-6. waits for the download to disappear from Lidarr's queue
-7. deletes the generated tracks it previously recorded
-8. removes the download from Splittarr's database
+5. stores input snapshots, cue-sheet results, generated track paths, file sizes, and errors in a SQLite database
+6. serves a small built-in web UI showing tracked downloads, statuses, and detail pages
+7. waits for the download to disappear from Lidarr's queue
+8. deletes the generated tracks it previously recorded
+9. keeps the download row in the database and marks it `completed`
 
 Splittarr does **not** delete the original album file, the CUE file, or arbitrary files in the download directory. Cleanup is based on the exact generated track paths recorded during splitting.
 
@@ -47,7 +48,17 @@ Album/
 └── Artist - Album - 03 - Third Track.flac
 ```
 
-Lidarr can then import the generated tracks. Once Lidarr no longer reports the download in its queue, Splittarr deletes the generated split files so the download directory is cleaned up.
+Lidarr can then import the generated tracks. Once Lidarr no longer reports the download in its queue, Splittarr deletes the generated split files so the download directory is cleaned up while keeping the full history in its database and UI.
+
+## Web UI
+
+Splittarr serves a built-in monitoring UI. By default it listens on `0.0.0.0:9899`.
+
+The UI includes:
+
+- a download history page at `/`
+- a detail page per tracked download at `/downloads/{download_id}`
+- lifecycle state, Lidarr state, cue results, input and output file snapshots, file sizes, and cleanup status
 
 ## Requirements
 
@@ -80,6 +91,7 @@ services:
       # Optional, defaults shown:
       SPLITTARR_DATA_DIR: /config
       SPLITTARR_CHECK_FREQUENCY_SECONDS: 60
+      SPLITTARR_SERVER__BIND_ADDRESS: 0.0.0.0:9899
       SPLITTARR_CUE__STRICT: "false"
       SPLITTARR_SHNSPLIT__PATH: shnsplit
       SPLITTARR_SHNSPLIT__OVERWRITE: "true"
@@ -119,6 +131,9 @@ Configuration is loaded in this order, with later sources overriding earlier one
 data_dir = "/config"
 check_frequency_seconds = 60
 
+[server]
+bind_address = "0.0.0.0:9899"
+
 [lidarr]
 url = "http://lidarr:8686"
 api_key = "your-lidarr-api-key"
@@ -152,6 +167,7 @@ Nested configuration keys use a double underscore.
 export SPLITTARR_LIDARR__URL=http://lidarr:8686
 export SPLITTARR_LIDARR__API_KEY=your-lidarr-api-key
 export SPLITTARR_CHECK_FREQUENCY_SECONDS=60
+export SPLITTARR_SERVER__BIND_ADDRESS=0.0.0.0:9899
 export SPLITTARR_SHNSPLIT__FORMAT="%p - %a - %n - %t"
 
 splittarr
@@ -163,6 +179,7 @@ splittarr
 | ------------------------- | ----------------------------------- | -------------------------------------- | ---------------------------------------------------------- |
 | `data_dir`                | `SPLITTARR_DATA_DIR`                | platform data dir, `/config` in Docker | Directory used for Splittarr's SQLite database.            |
 | `check_frequency_seconds` | `SPLITTARR_CHECK_FREQUENCY_SECONDS` | `60`                                   | How often Splittarr polls Lidarr's queue.                  |
+| `server.bind_address`     | `SPLITTARR_SERVER__BIND_ADDRESS`    | `0.0.0.0:9899`                         | Address for the built-in web UI and health endpoint.       |
 | `lidarr.url`              | `SPLITTARR_LIDARR__URL`             | required                               | Base URL for Lidarr, for example `http://lidarr:8686`.     |
 | `lidarr.api_key`          | `SPLITTARR_LIDARR__API_KEY`         | required                               | Lidarr API key.                                            |
 | `cue.strict`              | `SPLITTARR_CUE__STRICT`             | `false`                                | Whether CUE parsing should run in strict mode.             |
@@ -221,14 +238,17 @@ Splittarr keeps a SQLite database in `data_dir/data.db`.
 It stores:
 
 * Lidarr download IDs
+* lifecycle state and timestamps
 * discovered CUE files
+* input file snapshots and sizes
 * split status per CUE file
-* generated track paths
+* generated track paths and sizes
+* cleanup status per generated track
 * the last processing error, if any
 
 When a tracked download disappears from Lidarr's queue, Splittarr assumes Lidarr has either imported it or no longer needs it. Splittarr then deletes only the generated tracks recorded in its database.
 
-If a generated track is already gone, Splittarr ignores that and continues cleanup.
+If a generated track is already gone, Splittarr records that as `missing` and continues cleanup. Tracked downloads are never deleted from the database.
 
 ## Running locally
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Album/
 Lidarr can then import the generated tracks. Once Lidarr no longer reports the download in its queue, Splittarr deletes the generated split files so the download directory is cleaned up while keeping the full history in its database and UI.
 
 Splittarr serves a built-in monitoring UI. By default it listens on `127.0.0.1:9899`.
+The UI does not implement authentication, so avoid binding it to a public interface.
 The UI includes:
 
 - a download history page at `/`

--- a/README.md
+++ b/README.md
@@ -50,10 +50,7 @@ Album/
 
 Lidarr can then import the generated tracks. Once Lidarr no longer reports the download in its queue, Splittarr deletes the generated split files so the download directory is cleaned up while keeping the full history in its database and UI.
 
-## Web UI
-
-Splittarr serves a built-in monitoring UI. By default it listens on `0.0.0.0:9899`.
-
+Splittarr serves a built-in monitoring UI. By default it listens on `127.0.0.1:9899`.
 The UI includes:
 
 - a download history page at `/`

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ services:
       # Optional, defaults shown:
       SPLITTARR_DATA_DIR: /config
       SPLITTARR_CHECK_FREQUENCY_SECONDS: 60
-      SPLITTARR_SERVER__BIND_ADDRESS: 0.0.0.0:9899
+      SPLITTARR_SERVER__BIND_ADDRESS: 127.0.0.1:9899
       SPLITTARR_CUE__STRICT: "false"
       SPLITTARR_SHNSPLIT__PATH: shnsplit
       SPLITTARR_SHNSPLIT__OVERWRITE: "true"
@@ -129,7 +129,7 @@ data_dir = "/config"
 check_frequency_seconds = 60
 
 [server]
-bind_address = "0.0.0.0:9899"
+bind_address = "127.0.0.1:9899"
 
 [lidarr]
 url = "http://lidarr:8686"
@@ -164,7 +164,7 @@ Nested configuration keys use a double underscore.
 export SPLITTARR_LIDARR__URL=http://lidarr:8686
 export SPLITTARR_LIDARR__API_KEY=your-lidarr-api-key
 export SPLITTARR_CHECK_FREQUENCY_SECONDS=60
-export SPLITTARR_SERVER__BIND_ADDRESS=0.0.0.0:9899
+export SPLITTARR_SERVER__BIND_ADDRESS=127.0.0.1:9899
 export SPLITTARR_SHNSPLIT__FORMAT="%p - %a - %n - %t"
 
 splittarr
@@ -176,7 +176,7 @@ splittarr
 | ------------------------- | ----------------------------------- | -------------------------------------- | ---------------------------------------------------------- |
 | `data_dir`                | `SPLITTARR_DATA_DIR`                | platform data dir, `/config` in Docker | Directory used for Splittarr's SQLite database.            |
 | `check_frequency_seconds` | `SPLITTARR_CHECK_FREQUENCY_SECONDS` | `60`                                   | How often Splittarr polls Lidarr's queue.                  |
-| `server.bind_address`     | `SPLITTARR_SERVER__BIND_ADDRESS`    | `0.0.0.0:9899`                         | Address for the built-in web UI and health endpoint.       |
+| `server.bind_address`     | `SPLITTARR_SERVER__BIND_ADDRESS`    | `127.0.0.1:9899`                       | Address for the built-in web UI and health endpoint.       |
 | `lidarr.url`              | `SPLITTARR_LIDARR__URL`             | required                               | Base URL for Lidarr, for example `http://lidarr:8686`.     |
 | `lidarr.api_key`          | `SPLITTARR_LIDARR__API_KEY`         | required                               | Lidarr API key.                                            |
 | `cue.strict`              | `SPLITTARR_CUE__STRICT`             | `false`                                | Whether CUE parsing should run in strict mode.             |

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,6 +1,9 @@
 data_dir = "/config"
 check_frequency_seconds = 60
 
+[server]
+bind_address = "0.0.0.0:9899"
+
 [lidarr]
 url = "https://lidarr.example.com"
 api_key = "a3bb47a4968223c7568b06d4a2e9cf95"

--- a/config.toml.example
+++ b/config.toml.example
@@ -2,7 +2,7 @@ data_dir = "/config"
 check_frequency_seconds = 60
 
 [server]
-bind_address = "0.0.0.0:9899"
+bind_address = "127.0.0.1:9899"
 
 [lidarr]
 url = "https://lidarr.example.com"

--- a/config.toml.example
+++ b/config.toml.example
@@ -7,6 +7,8 @@ bind_address = "0.0.0.0:9899"
 [lidarr]
 url = "https://lidarr.example.com"
 api_key = "a3bb47a4968223c7568b06d4a2e9cf95"
+queue_page_size = 100
+queue_max_pages = 100
 
 [cue]
 strict = false

--- a/src/adapters/filesystem_cleanup.rs
+++ b/src/adapters/filesystem_cleanup.rs
@@ -142,6 +142,7 @@ mod tests {
                 message: None,
                 updated_at: String::new(),
             }],
+            generated_track_count: 1,
             last_error: None,
         };
 

--- a/src/adapters/filesystem_cleanup.rs
+++ b/src/adapters/filesystem_cleanup.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Result};
 
 use crate::application::ports::TrackCleanup;
-use crate::domain::{CueSheet, GeneratedTrack, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload};
+use crate::domain::{
+    CueSheet, GeneratedTrack, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct FilesystemTrackCleanup;

--- a/src/adapters/filesystem_cleanup.rs
+++ b/src/adapters/filesystem_cleanup.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Result};
 
 use crate::application::ports::TrackCleanup;
-use crate::domain::{CueSheet, GeneratedTrack, TrackedDownload};
+use crate::domain::{CueSheet, GeneratedTrack, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload};
 
 #[derive(Debug, Clone, Default)]
 pub struct FilesystemTrackCleanup;
@@ -16,7 +16,10 @@ impl FilesystemTrackCleanup {
 }
 
 impl TrackCleanup for FilesystemTrackCleanup {
-    async fn cleanup_download_tracks(&self, download: &TrackedDownload) -> Result<()> {
+    async fn cleanup_download_tracks(
+        &self,
+        download: &TrackedDownload,
+    ) -> Result<Vec<TrackCleanupOutcome>> {
         let download = download.clone();
         tokio::task::spawn_blocking(move || cleanup_download_tracks(&download))
             .await
@@ -24,25 +27,35 @@ impl TrackCleanup for FilesystemTrackCleanup {
     }
 }
 
-fn cleanup_download_tracks(download: &TrackedDownload) -> Result<()> {
-    let mut errors = Vec::new();
+fn cleanup_download_tracks(download: &TrackedDownload) -> Result<Vec<TrackCleanupOutcome>> {
+    let mut outcomes = Vec::new();
 
     for cue_sheet in &download.cue_sheets {
         for track in &cue_sheet.tracks {
             let path = cleanup_track_path(cue_sheet, track);
             match fs::remove_file(&path) {
-                Ok(()) => {}
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                Err(err) => errors.push(format!("{}: {err}", path.display())),
+                Ok(()) => outcomes.push(TrackCleanupOutcome {
+                    track_id: track.id.clone(),
+                    status: TrackCleanupStatus::Deleted,
+                    message: None,
+                }),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    outcomes.push(TrackCleanupOutcome {
+                        track_id: track.id.clone(),
+                        status: TrackCleanupStatus::Missing,
+                        message: Some(format!("{} was already absent", path.display())),
+                    })
+                }
+                Err(err) => outcomes.push(TrackCleanupOutcome {
+                    track_id: track.id.clone(),
+                    status: TrackCleanupStatus::DeleteFailed,
+                    message: Some(format!("{}: {err}", path.display())),
+                }),
             }
         }
     }
 
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(anyhow!("cleanup failed: {}", errors.join("; ")))
-    }
+    Ok(outcomes)
 }
 
 fn cleanup_track_path(cue_sheet: &CueSheet, track: &GeneratedTrack) -> PathBuf {
@@ -60,9 +73,9 @@ fn cleanup_track_path(cue_sheet: &CueSheet, track: &GeneratedTrack) -> PathBuf {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::domain::{CueSheet, CueSheetStatus, GeneratedTrack};
+    use crate::domain::{CueSheet, CueSheetStatus, GeneratedTrack, TrackCleanupStatus};
 
-    use super::cleanup_track_path;
+    use super::{cleanup_download_tracks, cleanup_track_path};
 
     #[test]
     fn cleanup_resolves_legacy_relative_track_paths_from_cue_directory() {
@@ -72,6 +85,7 @@ mod tests {
             path: "/downloads/album/album.cue".into(),
             status: CueSheetStatus::Split,
             message: None,
+            updated_at: "2024-01-01 00:00:00".into(),
             tracks: Vec::new(),
         };
         let track = GeneratedTrack {
@@ -79,11 +93,59 @@ mod tests {
             cue_sheet_id: "cue-1".into(),
             download_id: "download-1".into(),
             path: "01 - Track.flac".into(),
+            size_bytes: None,
+            cleanup_status: TrackCleanupStatus::Pending,
+            cleanup_message: None,
+            deleted_at: None,
         };
 
         assert_eq!(
             cleanup_track_path(&cue_sheet, &track),
             PathBuf::from("/downloads/album/01 - Track.flac")
         );
+    }
+
+    #[test]
+    fn cleanup_marks_missing_tracks_without_error() {
+        let download = crate::domain::TrackedDownload {
+            download_id: "download-1".into(),
+            title: "Album".into(),
+            status: "completed".into(),
+            output_path: "/downloads/album".into(),
+            tracked_download_state: "importFailed".into(),
+            lifecycle_state: crate::domain::DownloadLifecycleState::CleaningUp,
+            created_at: String::new(),
+            updated_at: String::new(),
+            first_seen_at: None,
+            last_seen_in_queue_at: None,
+            processing_started_at: None,
+            processing_finished_at: None,
+            cleanup_started_at: None,
+            cleanup_finished_at: None,
+            completed_at: None,
+            input_files: Vec::new(),
+            cue_sheets: vec![CueSheet {
+                tracks: vec![GeneratedTrack {
+                    id: "track-1".into(),
+                    cue_sheet_id: "cue-1".into(),
+                    download_id: "download-1".into(),
+                    path: "/tmp/not-here.flac".into(),
+                    size_bytes: None,
+                    cleanup_status: TrackCleanupStatus::Pending,
+                    cleanup_message: None,
+                    deleted_at: None,
+                }],
+                id: "cue-1".into(),
+                path: "/tmp/album.cue".into(),
+                download_id: "download-1".into(),
+                status: CueSheetStatus::Split,
+                message: None,
+                updated_at: String::new(),
+            }],
+            last_error: None,
+        };
+
+        let outcomes = cleanup_download_tracks(&download).unwrap();
+        assert_eq!(outcomes[0].status, TrackCleanupStatus::Missing);
     }
 }

--- a/src/adapters/lidarr_api.rs
+++ b/src/adapters/lidarr_api.rs
@@ -11,12 +11,16 @@ use crate::domain::{FailedImportCandidate, QueueSnapshot};
 pub struct LidarrQueueSource {
     base_url: String,
     api_key: String,
+    page_size: usize,
+    max_pages: usize,
     client: reqwest::Client,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct QueueResponse {
+    #[serde(default)]
+    total_records: Option<usize>,
     #[serde(default)]
     records: Vec<QueueRecord>,
 }
@@ -41,6 +45,8 @@ impl LidarrQueueSource {
         Self {
             base_url: settings.url.trim_end_matches('/').to_owned(),
             api_key: settings.api_key.clone(),
+            page_size: settings.queue_page_size.max(1),
+            max_pages: settings.queue_max_pages.max(1),
             client: reqwest::Client::new(),
         }
     }
@@ -48,36 +54,77 @@ impl LidarrQueueSource {
 
 impl QueueSource for LidarrQueueSource {
     async fn queue_snapshot(&self) -> Result<QueueSnapshot> {
-        let response = self
-            .client
-            .get(format!("{}/api/v1/queue", self.base_url))
-            .header("x-api-key", &self.api_key)
-            .send()
-            .await?;
-        let status = response.status();
-        let body = response.text().await?;
+        let mut page = 1_usize;
+        let mut pages_fetched = 0_usize;
+        let mut all_records = Vec::new();
+        let mut expected_total_records = None;
 
-        if !status.is_success() {
-            return Err(anyhow!("lidarr returned HTTP {status}: {body}"));
+        loop {
+            if page > self.max_pages {
+                return Err(anyhow!(
+                    "lidarr queue pagination exceeded max pages ({}) while fetching page {}",
+                    self.max_pages,
+                    page
+                ));
+            }
+
+            let response = self
+                .client
+                .get(format!("{}/api/v1/queue", self.base_url))
+                .query(&[("page", page), ("pageSize", self.page_size)])
+                .header("x-api-key", &self.api_key)
+                .send()
+                .await
+                .map_err(|err| anyhow!("failed requesting lidarr queue page {page}: {err}"))?;
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .map_err(|err| anyhow!("failed reading lidarr queue page {page}: {err}"))?;
+
+            if !status.is_success() {
+                return Err(anyhow!(
+                    "lidarr returned HTTP {status} for queue page {page}: {body}"
+                ));
+            }
+
+            let queue: QueueResponse = serde_json::from_str(&body).map_err(|err| {
+                anyhow!("lidarr returned invalid queue JSON for page {page}: {err}; body: {body}")
+            })?;
+
+            pages_fetched += 1;
+            expected_total_records = expected_total_records.or(queue.total_records);
+            let current_page_count = queue.records.len();
+            all_records.extend(queue.records);
+
+            if current_page_count == 0 {
+                break;
+            }
+            if let Some(total) = expected_total_records {
+                if all_records.len() >= total {
+                    break;
+                }
+            }
+            if current_page_count < self.page_size {
+                break;
+            }
+
+            page += 1;
         }
 
-        let queue: QueueResponse = serde_json::from_str(&body)
-            .map_err(|err| anyhow!("lidarr returned invalid queue JSON: {err}; body: {body}"))?;
-
-        let active_download_ids = queue
-            .records
+        let active_download_ids = all_records
             .iter()
             .filter_map(QueueRecord::download_id)
             .map(str::to_owned)
             .collect::<HashSet<_>>();
-        let failed_imports = queue
-            .records
+        let failed_imports = all_records
             .iter()
             .filter_map(QueueRecord::as_candidate)
             .collect::<Vec<_>>();
 
         Ok(QueueSnapshot {
-            total_records: queue.records.len(),
+            total_records: all_records.len(),
+            pages_fetched,
             active_download_ids,
             failed_imports,
         })
@@ -120,6 +167,9 @@ impl QueueRecord {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
@@ -161,12 +211,82 @@ mod tests {
         let client = LidarrQueueSource::new(&LidarrSettings {
             url,
             api_key: "secret".to_owned(),
+            queue_page_size: 100,
+            queue_max_pages: 100,
         });
 
         let queue = client.queue_snapshot().await.unwrap();
 
         assert_eq!(queue.total_records, 1);
+        assert_eq!(queue.pages_fetched, 1);
         assert!(queue.active_download_ids.contains("abc"));
+    }
+
+    #[tokio::test]
+    async fn client_fetches_multiple_pages_and_collects_failed_imports() {
+        let (url, _) = serve_sequence(vec![
+            (
+                "200 OK",
+                r#"{"totalRecords":2,"records":[{"title":"Downloading","status":"warning","trackedDownloadState":"downloading","downloadId":"down-1","outputPath":"/downloads/down-1"}]}"#,
+            ),
+            (
+                "200 OK",
+                r#"{"totalRecords":2,"records":[{"title":"Failed","status":"completed","trackedDownloadState":"importFailed","downloadId":"fail-1","outputPath":"/downloads/fail-1"}]}"#,
+            ),
+        ])
+        .await;
+        let client = LidarrQueueSource::new(&LidarrSettings {
+            url,
+            api_key: "secret".to_owned(),
+            queue_page_size: 1,
+            queue_max_pages: 100,
+        });
+
+        let queue = client.queue_snapshot().await.unwrap();
+
+        assert_eq!(queue.total_records, 2);
+        assert_eq!(queue.pages_fetched, 2);
+        assert!(queue.active_download_ids.contains("down-1"));
+        assert!(queue.active_download_ids.contains("fail-1"));
+        assert_eq!(queue.failed_imports.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn client_stops_when_short_page_is_returned() {
+        let (url, requests) = serve_sequence(vec![(
+            "200 OK",
+            r#"{"records":[{"title":"Album","status":"completed","trackedDownloadState":"importFailed","downloadId":"abc","outputPath":"/downloads/album"}]}"#,
+        )])
+        .await;
+        let client = LidarrQueueSource::new(&LidarrSettings {
+            url,
+            api_key: "secret".to_owned(),
+            queue_page_size: 100,
+            queue_max_pages: 100,
+        });
+
+        let queue = client.queue_snapshot().await.unwrap();
+        assert_eq!(queue.pages_fetched, 1);
+        assert_eq!(requests.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn client_stops_when_empty_page_is_returned() {
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", r#"{"totalRecords":5,"records":[{"downloadId":"a"}]}"#),
+            ("200 OK", r#"{"totalRecords":5,"records":[]}"#),
+        ])
+        .await;
+        let client = LidarrQueueSource::new(&LidarrSettings {
+            url,
+            api_key: "secret".to_owned(),
+            queue_page_size: 1,
+            queue_max_pages: 100,
+        });
+
+        let queue = client.queue_snapshot().await.unwrap();
+        assert_eq!(queue.pages_fetched, 2);
+        assert_eq!(requests.lock().unwrap().len(), 2);
     }
 
     #[tokio::test]
@@ -175,11 +295,14 @@ mod tests {
         let client = LidarrQueueSource::new(&LidarrSettings {
             url,
             api_key: "secret".to_owned(),
+            queue_page_size: 100,
+            queue_max_pages: 100,
         });
 
         let err = client.queue_snapshot().await.unwrap_err();
 
         assert!(err.to_string().contains("HTTP 500"));
+        assert!(err.to_string().contains("page 1"));
     }
 
     #[tokio::test]
@@ -188,26 +311,75 @@ mod tests {
         let client = LidarrQueueSource::new(&LidarrSettings {
             url,
             api_key: "secret".to_owned(),
+            queue_page_size: 100,
+            queue_max_pages: 100,
         });
 
         let err = client.queue_snapshot().await.unwrap_err();
 
         assert!(err.to_string().contains("invalid queue JSON"));
+        assert!(err.to_string().contains("page 1"));
+    }
+
+    #[tokio::test]
+    async fn client_errors_when_max_pages_is_exceeded() {
+        let (url, _) = serve_sequence(vec![
+            ("200 OK", r#"{"totalRecords":999,"records":[{"downloadId":"a"}]}"#),
+            ("200 OK", r#"{"totalRecords":999,"records":[{"downloadId":"b"}]}"#),
+            ("200 OK", r#"{"totalRecords":999,"records":[{"downloadId":"c"}]}"#),
+        ])
+        .await;
+        let client = LidarrQueueSource::new(&LidarrSettings {
+            url,
+            api_key: "secret".to_owned(),
+            queue_page_size: 1,
+            queue_max_pages: 2,
+        });
+
+        let err = client.queue_snapshot().await.unwrap_err();
+        assert!(err.to_string().contains("exceeded max pages"));
     }
 
     async fn serve_once(status: &'static str, body: &'static str) -> String {
+        let (url, _) = serve_sequence(vec![(status, body)]).await;
+        url
+    }
+
+    async fn serve_sequence(
+        responses: Vec<(&'static str, &'static str)>,
+    ) -> (String, Arc<Mutex<Vec<String>>>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        let request_lines = Arc::new(Mutex::new(Vec::new()));
+        let shared_lines = Arc::clone(&request_lines);
+        let shared_responses = Arc::new(Mutex::new(
+            responses.into_iter().collect::<VecDeque<(&'static str, &'static str)>>(),
+        ));
+        let queue = Arc::clone(&shared_responses);
+
         tokio::spawn(async move {
-            let (mut socket, _) = listener.accept().await.unwrap();
-            let mut request = [0_u8; 2048];
-            let _ = socket.read(&mut request).await.unwrap();
-            let response = format!(
-                "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                body.len()
-            );
-            socket.write_all(response.as_bytes()).await.unwrap();
+            loop {
+                let next = { queue.lock().unwrap().pop_front() };
+                let Some((status, body)) = next else {
+                    break;
+                };
+
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = [0_u8; 4096];
+                let bytes_read = socket.read(&mut request).await.unwrap();
+                let request_text = String::from_utf8_lossy(&request[..bytes_read]);
+                if let Some(line) = request_text.lines().next() {
+                    shared_lines.lock().unwrap().push(line.to_owned());
+                }
+
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
         });
-        format!("http://{addr}")
+
+        (format!("http://{addr}"), request_lines)
     }
 }

--- a/src/adapters/lidarr_api.rs
+++ b/src/adapters/lidarr_api.rs
@@ -273,7 +273,10 @@ mod tests {
     #[tokio::test]
     async fn client_stops_when_empty_page_is_returned() {
         let (url, requests) = serve_sequence(vec![
-            ("200 OK", r#"{"totalRecords":5,"records":[{"downloadId":"a"}]}"#),
+            (
+                "200 OK",
+                r#"{"totalRecords":5,"records":[{"downloadId":"a"}]}"#,
+            ),
             ("200 OK", r#"{"totalRecords":5,"records":[]}"#),
         ])
         .await;
@@ -324,9 +327,18 @@ mod tests {
     #[tokio::test]
     async fn client_errors_when_max_pages_is_exceeded() {
         let (url, _) = serve_sequence(vec![
-            ("200 OK", r#"{"totalRecords":999,"records":[{"downloadId":"a"}]}"#),
-            ("200 OK", r#"{"totalRecords":999,"records":[{"downloadId":"b"}]}"#),
-            ("200 OK", r#"{"totalRecords":999,"records":[{"downloadId":"c"}]}"#),
+            (
+                "200 OK",
+                r#"{"totalRecords":999,"records":[{"downloadId":"a"}]}"#,
+            ),
+            (
+                "200 OK",
+                r#"{"totalRecords":999,"records":[{"downloadId":"b"}]}"#,
+            ),
+            (
+                "200 OK",
+                r#"{"totalRecords":999,"records":[{"downloadId":"c"}]}"#,
+            ),
         ])
         .await;
         let client = LidarrQueueSource::new(&LidarrSettings {
@@ -353,7 +365,9 @@ mod tests {
         let request_lines = Arc::new(Mutex::new(Vec::new()));
         let shared_lines = Arc::clone(&request_lines);
         let shared_responses = Arc::new(Mutex::new(
-            responses.into_iter().collect::<VecDeque<(&'static str, &'static str)>>(),
+            responses
+                .into_iter()
+                .collect::<VecDeque<(&'static str, &'static str)>>(),
         ));
         let queue = Arc::clone(&shared_responses);
 

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -3,3 +3,4 @@ pub mod filesystem_cue_scanner;
 pub mod lidarr_api;
 pub mod shnsplit_splitter;
 pub mod sqlite_download_store;
+pub mod web;

--- a/src/adapters/shnsplit_splitter.rs
+++ b/src/adapters/shnsplit_splitter.rs
@@ -75,7 +75,7 @@ impl ShnsplitCueSplitter {
         }
 
         let overwrite = if self.overwrite { "always" } else { "never" };
-        let files_before = snapshot_audio_files(cue_dir)?;
+        let files_before = snapshot_audio_files_best_effort(cue_dir, cue_path);
         let output = {
             let mut command = Command::new(&self.shnsplit_path);
             command
@@ -115,7 +115,7 @@ impl ShnsplitCueSplitter {
 
         let mut tracks = parse_generated_tracks(cue_dir, &stderr);
         if tracks.is_empty() {
-            let files_after = snapshot_audio_files(cue_dir)?;
+            let files_after = snapshot_audio_files_best_effort(cue_dir, cue_path);
             tracks = detect_generated_tracks(&referenced_paths, &files_before, &files_after);
         }
         if tracks.is_empty() {
@@ -202,6 +202,19 @@ fn snapshot_audio_files(root: &Path) -> Result<BTreeSet<FileSnapshot>> {
     Ok(files)
 }
 
+fn snapshot_audio_files_best_effort(root: &Path, cue_path: &Path) -> BTreeSet<FileSnapshot> {
+    match snapshot_audio_files(root) {
+        Ok(files) => files,
+        Err(err) => {
+            eprintln!(
+                "Unable to snapshot audio files for {}: {err}",
+                cue_path.display()
+            );
+            BTreeSet::new()
+        }
+    }
+}
+
 fn is_flac_file(path: &Path) -> bool {
     path.extension()
         .and_then(|extension| extension.to_str())
@@ -237,7 +250,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        decoder_args, detect_generated_tracks, parse_generated_tracks, ShnsplitCueSplitter,
+        decoder_args, detect_generated_tracks, parse_generated_tracks, snapshot_audio_files_best_effort,
+        ShnsplitCueSplitter,
     };
     use crate::domain::SplitStatus;
 
@@ -367,6 +381,17 @@ exit 0
 
         assert!(args.contains("-i"));
         assert!(args.contains("flac flac -cd -s %f"));
+    }
+
+    #[test]
+    fn best_effort_snapshot_failure_does_not_block_stderr_track_detection() {
+        let tmp = tempdir().unwrap();
+        let cue_path = tmp.path().join("album.cue");
+        let missing_dir = tmp.path().join("missing");
+
+        let files = snapshot_audio_files_best_effort(&missing_dir, &cue_path);
+
+        assert!(files.is_empty());
     }
 
     fn test_splitter(shnsplit_path: PathBuf) -> ShnsplitCueSplitter {

--- a/src/adapters/shnsplit_splitter.rs
+++ b/src/adapters/shnsplit_splitter.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::SystemTime;
 
 use anyhow::{anyhow, Result};
 use rcue::parser::parse_from_file;
@@ -59,6 +61,10 @@ impl ShnsplitCueSplitter {
             .map(|file| file.file.as_str())
             .filter(|file| cue_dir.join(file).exists())
             .collect::<BTreeSet<_>>();
+        let referenced_paths = referenced_files
+            .iter()
+            .map(|file| cue_dir.join(file))
+            .collect::<Vec<_>>();
 
         if referenced_files.is_empty() {
             return Ok(SplitOutcome {
@@ -69,6 +75,7 @@ impl ShnsplitCueSplitter {
         }
 
         let overwrite = if self.overwrite { "always" } else { "never" };
+        let files_before = snapshot_audio_files(cue_dir)?;
         let output = {
             let mut command = Command::new(&self.shnsplit_path);
             command
@@ -79,6 +86,7 @@ impl ShnsplitCueSplitter {
                 .arg(cue_dir)
                 .arg("-t")
                 .arg(&self.format)
+                .args(decoder_args(&referenced_paths))
                 .arg("-O")
                 .arg(overwrite)
                 .arg("-o")
@@ -105,7 +113,11 @@ impl ShnsplitCueSplitter {
             ));
         }
 
-        let tracks = parse_generated_tracks(cue_dir, &stderr);
+        let mut tracks = parse_generated_tracks(cue_dir, &stderr);
+        if tracks.is_empty() {
+            let files_after = snapshot_audio_files(cue_dir)?;
+            tracks = detect_generated_tracks(&referenced_paths, &files_before, &files_after);
+        }
         if tracks.is_empty() {
             return Err(anyhow!(
                 "shnsplit succeeded for {} but no generated tracks were detected",
@@ -149,6 +161,71 @@ fn parse_generated_tracks(cue_dir: &Path, stderr: &str) -> Vec<PathBuf> {
         .collect()
 }
 
+fn decoder_args(referenced_paths: &[PathBuf]) -> Vec<&'static str> {
+    if referenced_paths.is_empty() || !referenced_paths.iter().all(|path| is_flac_file(path)) {
+        return Vec::new();
+    }
+    vec!["-i", "flac flac -cd -s %f"]
+}
+
+fn detect_generated_tracks(
+    referenced_paths: &[PathBuf],
+    before: &BTreeSet<FileSnapshot>,
+    after: &BTreeSet<FileSnapshot>,
+) -> Vec<PathBuf> {
+    after
+        .iter()
+        .filter(|snapshot| !referenced_paths.iter().any(|path| path == &snapshot.path))
+        .filter(|snapshot| !before.contains(snapshot))
+        .map(|snapshot| snapshot.path.clone())
+        .collect()
+}
+
+fn snapshot_audio_files(root: &Path) -> Result<BTreeSet<FileSnapshot>> {
+    let mut files = BTreeSet::new();
+    for entry in fs::read_dir(root)
+        .map_err(|err| anyhow!("failed to list cue directory {}: {err}", root.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file() || !is_audio_file(&path) {
+            continue;
+        }
+
+        let metadata = entry.metadata()?;
+        files.insert(FileSnapshot {
+            path,
+            size: metadata.len(),
+            modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+        });
+    }
+    Ok(files)
+}
+
+fn is_flac_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("flac"))
+}
+
+fn is_audio_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            matches!(
+                extension.to_ascii_lowercase().as_str(),
+                "flac" | "wav" | "ape" | "wv" | "m4a" | "mp3" | "ogg" | "opus" | "tta" | "aiff"
+            )
+        })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct FileSnapshot {
+    path: PathBuf,
+    size: u64,
+    modified: SystemTime,
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -159,7 +236,9 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::{parse_generated_tracks, ShnsplitCueSplitter};
+    use super::{
+        decoder_args, detect_generated_tracks, parse_generated_tracks, ShnsplitCueSplitter,
+    };
     use crate::domain::SplitStatus;
 
     #[test]
@@ -223,6 +302,71 @@ exit 2
         let tracks = parse_generated_tracks(tmp.path(), stderr);
 
         assert_eq!(tracks, vec![tmp.path().join("01 - Track.flac")]);
+    }
+
+    #[test]
+    fn falls_back_to_filesystem_detection_when_stderr_has_no_track_lines() {
+        let tmp = tempdir().unwrap();
+        let input = tmp.path().join("album.flac");
+        let output = tmp.path().join("01 - Track.flac");
+        fs::write(&input, b"input").unwrap();
+        let before = super::snapshot_audio_files(tmp.path()).unwrap();
+        fs::write(&output, b"track").unwrap();
+        let after = super::snapshot_audio_files(tmp.path()).unwrap();
+
+        let tracks = detect_generated_tracks(&[input], &before, &after);
+
+        assert_eq!(tracks, vec![output]);
+    }
+
+    #[test]
+    fn uses_explicit_flac_decoder_for_flac_inputs() {
+        let args = decoder_args(&[PathBuf::from("album.flac")]);
+
+        assert_eq!(args, vec!["-i", "flac flac -cd -s %f"]);
+    }
+
+    #[test]
+    fn splitter_detects_tracks_without_matching_stderr() {
+        let tmp = tempdir().unwrap();
+        let cue_path = write_fixture_album(tmp.path(), true);
+        let fake = write_fake_shnsplit(
+            tmp.path(),
+            r#"touch "Artist - Album - 01 - Track One.flac"
+echo "split complete" >&2
+exit 0
+"#,
+        );
+        let splitter = test_splitter(fake);
+
+        let result = splitter.split_cue_sync(&cue_path).unwrap();
+
+        assert_eq!(result.status, SplitStatus::Split);
+        assert_eq!(
+            result.tracks,
+            vec![tmp.path().join("Artist - Album - 01 - Track One.flac")]
+        );
+    }
+
+    #[test]
+    fn splitter_passes_flac_decoder_argument() {
+        let tmp = tempdir().unwrap();
+        let cue_path = write_fixture_album(tmp.path(), true);
+        let args_log = tmp.path().join("args.log");
+        let fake = write_fake_shnsplit(
+            tmp.path(),
+            &format!(
+                "printf '%s\\n' \"$@\" > \"{}\"\ntouch \"Artist - Album - 01 - Track One.flac\"\necho \"Splitting [album.flac] (0:01.00) --> [Artist - Album - 01 - Track One.flac] (0:01.00) :\" >&2\nexit 0\n",
+                args_log.display()
+            ),
+        );
+        let splitter = test_splitter(fake);
+
+        splitter.split_cue_sync(&cue_path).unwrap();
+        let args = fs::read_to_string(args_log).unwrap();
+
+        assert!(args.contains("-i"));
+        assert!(args.contains("flac flac -cd -s %f"));
     }
 
     fn test_splitter(shnsplit_path: PathBuf) -> ShnsplitCueSplitter {

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -6,7 +6,10 @@ use rusqlite::{named_params, params, Connection, OptionalExtension};
 use uuid::Uuid;
 
 use crate::application::ports::DownloadStore;
-use crate::domain::{CueSheet, CueSheetStatus, GeneratedTrack, TrackedDownload};
+use crate::domain::{
+    CueSheet, CueSheetStatus, DownloadLifecycleState, GeneratedTrack, InputFile, InputFileKind,
+    RecordedTrack, TrackCleanupStatus, TrackedDownload,
+};
 
 #[derive(Debug, Clone)]
 pub struct SqliteDownloadStore {
@@ -33,49 +36,55 @@ impl SqliteDownloadStore {
         let conn = self.connect()?;
         let mut stmt = conn.prepare(
             "SELECT download_id, title, status, output_path, tracked_download_state,
-                    split_complete, last_error
+                    lifecycle_state, created_at, updated_at, first_seen_at, last_seen_in_queue_at,
+                    processing_started_at, processing_finished_at, cleanup_started_at,
+                    cleanup_finished_at, completed_at, last_error
              FROM downloads
-             ORDER BY title, download_id",
+             ORDER BY updated_at DESC, download_id DESC",
         )?;
-        let rows = stmt.query_map([], |row| {
-            Ok(TrackedDownload {
-                download_id: row.get(0)?,
-                title: row.get(1)?,
-                status: row.get(2)?,
-                output_path: row.get(3)?,
-                tracked_download_state: row.get(4)?,
-                split_complete: row.get(5)?,
-                last_error: row.get(6)?,
-                cue_sheets: Vec::new(),
-            })
-        })?;
+        let rows = stmt.query_map([], |row| map_download_row(&conn, row))?;
 
         let mut downloads = Vec::new();
         for row in rows {
-            let mut download = row?;
-            download.cue_sheets = cue_sheets_for(&conn, &download.download_id)?;
-            downloads.push(download);
+            downloads.push(row?);
         }
         Ok(downloads)
+    }
+
+    fn get_tracked_download_sync(&self, download_id: &str) -> Result<Option<TrackedDownload>> {
+        let conn = self.connect()?;
+        conn.query_row(
+            "SELECT download_id, title, status, output_path, tracked_download_state,
+                    lifecycle_state, created_at, updated_at, first_seen_at, last_seen_in_queue_at,
+                    processing_started_at, processing_finished_at, cleanup_started_at,
+                    cleanup_finished_at, completed_at, last_error
+             FROM downloads
+             WHERE download_id = ?",
+            [download_id],
+            |row| map_download_row(&conn, row),
+        )
+        .optional()
+        .map_err(Into::into)
     }
 
     fn upsert_tracked_download_sync(&self, download: &TrackedDownload) -> Result<()> {
         let conn = self.connect()?;
         conn.execute(
             "INSERT INTO downloads (
-                download_id, title, status, output_path, tracked_download_state,
-                split_complete, last_error, updated_at
+                download_id, title, status, output_path, tracked_download_state, lifecycle_state,
+                created_at, updated_at, first_seen_at, last_seen_in_queue_at, last_error
              )
              VALUES (
-                :download_id, :title, :status, :output_path, :tracked_download_state,
-                :split_complete, :last_error, CURRENT_TIMESTAMP
+                :download_id, :title, :status, :output_path, :tracked_download_state, :lifecycle_state,
+                CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, :last_error
              )
              ON CONFLICT(download_id) DO UPDATE SET
                 title = excluded.title,
                 status = excluded.status,
                 output_path = excluded.output_path,
                 tracked_download_state = excluded.tracked_download_state,
-                split_complete = excluded.split_complete,
+                lifecycle_state = excluded.lifecycle_state,
+                last_seen_in_queue_at = CURRENT_TIMESTAMP,
                 last_error = excluded.last_error,
                 updated_at = CURRENT_TIMESTAMP",
             named_params! {
@@ -84,31 +93,96 @@ impl SqliteDownloadStore {
                 ":status": &download.status,
                 ":output_path": &download.output_path,
                 ":tracked_download_state": &download.tracked_download_state,
-                ":split_complete": download.split_complete,
+                ":lifecycle_state": download.lifecycle_state.as_str(),
                 ":last_error": &download.last_error,
             },
         )?;
         Ok(())
     }
 
-    fn mark_download_complete_sync(
-        &self,
-        download_id: &str,
-        split_complete: bool,
-        last_error: Option<&str>,
-    ) -> Result<()> {
+    fn touch_download_queue_presence_sync(&self, download_id: &str) -> Result<()> {
         let conn = self.connect()?;
         conn.execute(
             "UPDATE downloads
-             SET split_complete = :split_complete,
-                 last_error = :last_error,
+             SET last_seen_in_queue_at = CURRENT_TIMESTAMP,
                  updated_at = CURRENT_TIMESTAMP
-             WHERE download_id = :download_id",
-            named_params! {
-                ":download_id": download_id,
-                ":split_complete": split_complete,
-                ":last_error": last_error,
-            },
+             WHERE download_id = ?",
+            [download_id],
+        )?;
+        Ok(())
+    }
+
+    fn mark_download_processing_sync(&self, download_id: &str) -> Result<()> {
+        let conn = self.connect()?;
+        conn.execute(
+            "UPDATE downloads
+             SET lifecycle_state = 'processing',
+                 processing_started_at = COALESCE(processing_started_at, CURRENT_TIMESTAMP),
+                 last_error = NULL,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE download_id = ?",
+            [download_id],
+        )?;
+        Ok(())
+    }
+
+    fn mark_download_awaiting_import_sync(&self, download_id: &str) -> Result<()> {
+        let conn = self.connect()?;
+        conn.execute(
+            "UPDATE downloads
+             SET lifecycle_state = 'awaiting_import',
+                 processing_finished_at = CURRENT_TIMESTAMP,
+                 last_error = NULL,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE download_id = ?",
+            [download_id],
+        )?;
+        Ok(())
+    }
+
+    fn mark_download_cleanup_started_sync(&self, download_id: &str) -> Result<()> {
+        let conn = self.connect()?;
+        conn.execute(
+            "UPDATE downloads
+             SET lifecycle_state = 'cleaning_up',
+                 cleanup_started_at = COALESCE(cleanup_started_at, CURRENT_TIMESTAMP),
+                 last_error = NULL,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE download_id = ?",
+            [download_id],
+        )?;
+        Ok(())
+    }
+
+    fn mark_download_completed_sync(&self, download_id: &str) -> Result<()> {
+        let conn = self.connect()?;
+        conn.execute(
+            "UPDATE downloads
+             SET lifecycle_state = 'completed',
+                 cleanup_finished_at = CURRENT_TIMESTAMP,
+                 completed_at = CURRENT_TIMESTAMP,
+                 last_error = NULL,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE download_id = ?",
+            [download_id],
+        )?;
+        Ok(())
+    }
+
+    fn mark_download_failed_sync(&self, download_id: &str, last_error: Option<&str>) -> Result<()> {
+        let conn = self.connect()?;
+        conn.execute(
+            "UPDATE downloads
+             SET lifecycle_state = 'failed',
+                 processing_finished_at = COALESCE(processing_finished_at, CURRENT_TIMESTAMP),
+                 cleanup_finished_at = CASE
+                     WHEN lifecycle_state = 'cleaning_up' THEN CURRENT_TIMESTAMP
+                     ELSE cleanup_finished_at
+                 END,
+                 last_error = ?2,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE download_id = ?1",
+            params![download_id, last_error],
         )?;
         Ok(())
     }
@@ -132,12 +206,41 @@ impl SqliteDownloadStore {
             .ok_or_else(|| anyhow!("cue file row disappeared after insert: {path}"))
     }
 
+    fn record_input_file_sync(
+        &self,
+        download_id: &str,
+        cue_sheet_id: Option<&str>,
+        path: &Path,
+        kind: InputFileKind,
+        size_bytes: Option<i64>,
+    ) -> Result<()> {
+        let conn = self.connect()?;
+        conn.execute(
+            "INSERT INTO input_files (id, download_id, cue_file_id, path, kind, size_bytes, captured_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, CURRENT_TIMESTAMP)
+             ON CONFLICT(download_id, path) DO UPDATE SET
+                cue_file_id = excluded.cue_file_id,
+                kind = excluded.kind,
+                size_bytes = excluded.size_bytes,
+                captured_at = CURRENT_TIMESTAMP",
+            params![
+                Uuid::new_v4().to_string(),
+                download_id,
+                cue_sheet_id,
+                path.to_string_lossy().to_string(),
+                kind.as_str(),
+                size_bytes,
+            ],
+        )?;
+        Ok(())
+    }
+
     fn record_cue_result_sync(
         &self,
         cue_sheet: &CueSheet,
         status: CueSheetStatus,
         message: Option<&str>,
-        tracks: &[PathBuf],
+        tracks: &[RecordedTrack],
     ) -> Result<()> {
         let mut conn = self.connect()?;
         let tx = conn.transaction()?;
@@ -156,14 +259,20 @@ impl SqliteDownloadStore {
 
         for track in tracks {
             tx.execute(
-                "INSERT OR IGNORE INTO tracks (id, path, cue_file_id, download_id)
-                 VALUES (:id, :path, :cue_file_id, :download_id)",
-                named_params! {
-                    ":id": Uuid::new_v4().to_string(),
-                    ":path": track.to_string_lossy().to_string(),
-                    ":cue_file_id": &cue_sheet.id,
-                    ":download_id": &cue_sheet.download_id,
-                },
+                "INSERT INTO tracks (
+                    id, path, cue_file_id, download_id, size_bytes, cleanup_status, cleanup_message, deleted_at
+                 )
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'pending', NULL, NULL)
+                 ON CONFLICT(download_id, path) DO UPDATE SET
+                    cue_file_id = excluded.cue_file_id,
+                    size_bytes = excluded.size_bytes",
+                params![
+                    Uuid::new_v4().to_string(),
+                    &track.path,
+                    &cue_sheet.id,
+                    &cue_sheet.download_id,
+                    track.size_bytes,
+                ],
             )?;
         }
 
@@ -171,12 +280,33 @@ impl SqliteDownloadStore {
         Ok(())
     }
 
-    fn delete_download_sync(&self, download_id: &str) -> Result<()> {
-        let conn = self.connect()?;
-        conn.execute(
-            "DELETE FROM downloads WHERE download_id = :download_id",
-            named_params! { ":download_id": download_id },
+    fn record_track_cleanup_sync(
+        &self,
+        download_id: &str,
+        track_id: &str,
+        status: TrackCleanupStatus,
+        message: Option<&str>,
+    ) -> Result<()> {
+        let mut conn = self.connect()?;
+        let tx = conn.transaction()?;
+        tx.execute(
+            "UPDATE tracks
+             SET cleanup_status = ?2,
+                 cleanup_message = ?3,
+                 deleted_at = CASE
+                     WHEN ?2 IN ('deleted', 'missing') THEN CURRENT_TIMESTAMP
+                     ELSE NULL
+                 END
+             WHERE id = ?1",
+            params![track_id, status.as_str(), message],
         )?;
+        tx.execute(
+            "UPDATE downloads
+             SET updated_at = CURRENT_TIMESTAMP
+             WHERE download_id = ?",
+            [download_id],
+        )?;
+        tx.commit()?;
         Ok(())
     }
 }
@@ -189,6 +319,14 @@ impl DownloadStore for SqliteDownloadStore {
             .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
 
+    async fn get_tracked_download(&self, download_id: &str) -> Result<Option<TrackedDownload>> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        tokio::task::spawn_blocking(move || store.get_tracked_download_sync(&download_id))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
     async fn upsert_tracked_download(&self, download: &TrackedDownload) -> Result<()> {
         let store = self.clone();
         let download = download.clone();
@@ -197,17 +335,52 @@ impl DownloadStore for SqliteDownloadStore {
             .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
 
-    async fn mark_download_complete(
-        &self,
-        download_id: &str,
-        split_complete: bool,
-        last_error: Option<&str>,
-    ) -> Result<()> {
+    async fn touch_download_queue_presence(&self, download_id: &str) -> Result<()> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        tokio::task::spawn_blocking(move || store.touch_download_queue_presence_sync(&download_id))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn mark_download_processing(&self, download_id: &str) -> Result<()> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        tokio::task::spawn_blocking(move || store.mark_download_processing_sync(&download_id))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn mark_download_awaiting_import(&self, download_id: &str) -> Result<()> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        tokio::task::spawn_blocking(move || store.mark_download_awaiting_import_sync(&download_id))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn mark_download_cleanup_started(&self, download_id: &str) -> Result<()> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        tokio::task::spawn_blocking(move || store.mark_download_cleanup_started_sync(&download_id))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn mark_download_completed(&self, download_id: &str) -> Result<()> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        tokio::task::spawn_blocking(move || store.mark_download_completed_sync(&download_id))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn mark_download_failed(&self, download_id: &str, last_error: Option<&str>) -> Result<()> {
         let store = self.clone();
         let download_id = download_id.to_owned();
         let last_error = last_error.map(str::to_owned);
         tokio::task::spawn_blocking(move || {
-            store.mark_download_complete_sync(&download_id, split_complete, last_error.as_deref())
+            store.mark_download_failed_sync(&download_id, last_error.as_deref())
         })
         .await
         .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
@@ -222,12 +395,37 @@ impl DownloadStore for SqliteDownloadStore {
             .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
 
+    async fn record_input_file(
+        &self,
+        download_id: &str,
+        cue_sheet_id: Option<&str>,
+        path: &Path,
+        kind: InputFileKind,
+        size_bytes: Option<i64>,
+    ) -> Result<()> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        let cue_sheet_id = cue_sheet_id.map(str::to_owned);
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            store.record_input_file_sync(
+                &download_id,
+                cue_sheet_id.as_deref(),
+                &path,
+                kind,
+                size_bytes,
+            )
+        })
+        .await
+        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
     async fn record_cue_result(
         &self,
         cue_sheet: &CueSheet,
         status: CueSheetStatus,
         message: Option<&str>,
-        tracks: &[PathBuf],
+        tracks: &[RecordedTrack],
     ) -> Result<()> {
         let store = self.clone();
         let cue_sheet = cue_sheet.clone();
@@ -240,18 +438,52 @@ impl DownloadStore for SqliteDownloadStore {
         .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
 
-    async fn delete_download(&self, download_id: &str) -> Result<()> {
+    async fn record_track_cleanup(
+        &self,
+        download_id: &str,
+        track_id: &str,
+        status: TrackCleanupStatus,
+        message: Option<&str>,
+    ) -> Result<()> {
         let store = self.clone();
         let download_id = download_id.to_owned();
-        tokio::task::spawn_blocking(move || store.delete_download_sync(&download_id))
-            .await
-            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+        let track_id = track_id.to_owned();
+        let message = message.map(str::to_owned);
+        tokio::task::spawn_blocking(move || {
+            store.record_track_cleanup_sync(&download_id, &track_id, status, message.as_deref())
+        })
+        .await
+        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
 }
 
-fn cue_sheets_for(conn: &Connection, download_id: &str) -> Result<Vec<CueSheet>> {
+fn map_download_row(conn: &Connection, row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedDownload> {
+    let download_id: String = row.get(0)?;
+    Ok(TrackedDownload {
+        input_files: input_files_for(conn, &download_id)?,
+        cue_sheets: cue_sheets_for(conn, &download_id)?,
+        download_id,
+        title: row.get(1)?,
+        status: row.get(2)?,
+        output_path: row.get(3)?,
+        tracked_download_state: row.get(4)?,
+        lifecycle_state: DownloadLifecycleState::from_db(row.get::<_, String>(5)?.as_str()),
+        created_at: row.get(6)?,
+        updated_at: row.get(7)?,
+        first_seen_at: row.get(8)?,
+        last_seen_in_queue_at: row.get(9)?,
+        processing_started_at: row.get(10)?,
+        processing_finished_at: row.get(11)?,
+        cleanup_started_at: row.get(12)?,
+        cleanup_finished_at: row.get(13)?,
+        completed_at: row.get(14)?,
+        last_error: row.get(15)?,
+    })
+}
+
+fn cue_sheets_for(conn: &Connection, download_id: &str) -> rusqlite::Result<Vec<CueSheet>> {
     let mut stmt = conn.prepare(
-        "SELECT id, path, download_id, status, message
+        "SELECT id, path, download_id, status, message, updated_at
          FROM cue_files
          WHERE download_id = ?
          ORDER BY path",
@@ -265,6 +497,7 @@ fn cue_sheets_for(conn: &Connection, download_id: &str) -> Result<Vec<CueSheet>>
             download_id: row.get(2)?,
             status: CueSheetStatus::from_db(row.get::<_, String>(3)?.as_str()),
             message: row.get(4)?,
+            updated_at: row.get(5)?,
         })
     })?;
 
@@ -275,13 +508,39 @@ fn cue_sheets_for(conn: &Connection, download_id: &str) -> Result<Vec<CueSheet>>
     Ok(cue_sheets)
 }
 
+fn input_files_for(conn: &Connection, download_id: &str) -> rusqlite::Result<Vec<InputFile>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, download_id, cue_file_id, path, kind, size_bytes, captured_at
+         FROM input_files
+         WHERE download_id = ?
+         ORDER BY kind, path",
+    )?;
+    let rows = stmt.query_map([download_id], |row| {
+        Ok(InputFile {
+            id: row.get(0)?,
+            download_id: row.get(1)?,
+            cue_sheet_id: row.get(2)?,
+            path: row.get(3)?,
+            kind: InputFileKind::from_db(row.get::<_, String>(4)?.as_str()),
+            size_bytes: row.get(5)?,
+            captured_at: row.get(6)?,
+        })
+    })?;
+
+    let mut files = Vec::new();
+    for row in rows {
+        files.push(row?);
+    }
+    Ok(files)
+}
+
 fn cue_sheet_by_download_and_path(
     conn: &Connection,
     download_id: &str,
     path: &str,
-) -> Result<Option<CueSheet>> {
+) -> rusqlite::Result<Option<CueSheet>> {
     conn.query_row(
-        "SELECT id, path, download_id, status, message
+        "SELECT id, path, download_id, status, message, updated_at
          FROM cue_files
          WHERE download_id = ? AND path = ?",
         params![download_id, path],
@@ -294,6 +553,7 @@ fn cue_sheet_by_download_and_path(
                 download_id: row.get(2)?,
                 status: CueSheetStatus::from_db(row.get::<_, String>(3)?.as_str()),
                 message: row.get(4)?,
+                updated_at: row.get(5)?,
             })
         },
     )
@@ -301,12 +561,9 @@ fn cue_sheet_by_download_and_path(
     .map_err(Into::into)
 }
 
-fn tracks_for(
-    conn: &Connection,
-    cue_sheet_id: &str,
-) -> Result<Vec<GeneratedTrack>, rusqlite::Error> {
+fn tracks_for(conn: &Connection, cue_sheet_id: &str) -> Result<Vec<GeneratedTrack>, rusqlite::Error> {
     let mut stmt = conn.prepare(
-        "SELECT id, cue_file_id, download_id, path
+        "SELECT id, cue_file_id, download_id, path, size_bytes, cleanup_status, cleanup_message, deleted_at
          FROM tracks
          WHERE cue_file_id = ?
          ORDER BY path",
@@ -317,6 +574,10 @@ fn tracks_for(
             cue_sheet_id: row.get(1)?,
             download_id: row.get(2)?,
             path: row.get(3)?,
+            size_bytes: row.get(4)?,
+            cleanup_status: TrackCleanupStatus::from_db(row.get::<_, String>(5)?.as_str()),
+            cleanup_message: row.get(6)?,
+            deleted_at: row.get(7)?,
         })
     })?;
 
@@ -336,9 +597,18 @@ fn migrate(conn: &mut Connection) -> Result<()> {
             status                 TEXT NOT NULL,
             output_path            TEXT NOT NULL,
             tracked_download_state TEXT NOT NULL,
+            lifecycle_state        TEXT,
             split_complete         BOOLEAN NOT NULL DEFAULT FALSE,
-            last_error             TEXT,
-            updated_at             TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            created_at             TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at             TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            first_seen_at          TEXT,
+            last_seen_in_queue_at  TEXT,
+            processing_started_at  TEXT,
+            processing_finished_at TEXT,
+            cleanup_started_at     TEXT,
+            cleanup_finished_at    TEXT,
+            completed_at           TEXT,
+            last_error             TEXT
         );
 
         CREATE TABLE IF NOT EXISTS cue_files (
@@ -351,21 +621,38 @@ fn migrate(conn: &mut Connection) -> Result<()> {
             FOREIGN KEY(download_id) REFERENCES downloads(download_id) ON DELETE CASCADE
         );
 
-        CREATE TABLE IF NOT EXISTS tracks (
+        CREATE TABLE IF NOT EXISTS input_files (
             id          TEXT PRIMARY KEY,
-            path        TEXT NOT NULL,
-            cue_file_id TEXT NOT NULL,
             download_id TEXT NOT NULL,
+            cue_file_id TEXT,
+            path        TEXT NOT NULL,
+            kind        TEXT NOT NULL,
+            size_bytes  INTEGER,
+            captured_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY(download_id) REFERENCES downloads(download_id) ON DELETE CASCADE,
+            FOREIGN KEY(cue_file_id) REFERENCES cue_files(id) ON DELETE SET NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS tracks (
+            id              TEXT PRIMARY KEY,
+            path            TEXT NOT NULL,
+            cue_file_id     TEXT NOT NULL,
+            download_id     TEXT NOT NULL,
+            size_bytes      INTEGER,
+            cleanup_status  TEXT NOT NULL DEFAULT 'pending',
+            cleanup_message TEXT,
+            deleted_at      TEXT,
             FOREIGN KEY(cue_file_id) REFERENCES cue_files(id) ON DELETE CASCADE,
             FOREIGN KEY(download_id) REFERENCES downloads(download_id) ON DELETE CASCADE
         );",
     )?;
 
+    add_column_if_missing(&tx, "downloads", "lifecycle_state", "ALTER TABLE downloads ADD COLUMN lifecycle_state TEXT")?;
     add_column_if_missing(
         &tx,
         "downloads",
-        "last_error",
-        "ALTER TABLE downloads ADD COLUMN last_error TEXT",
+        "created_at",
+        "ALTER TABLE downloads ADD COLUMN created_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00'",
     )?;
     add_column_if_missing(
         &tx,
@@ -373,29 +660,99 @@ fn migrate(conn: &mut Connection) -> Result<()> {
         "updated_at",
         "ALTER TABLE downloads ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00'",
     )?;
+    add_column_if_missing(&tx, "downloads", "first_seen_at", "ALTER TABLE downloads ADD COLUMN first_seen_at TEXT")?;
     add_column_if_missing(
         &tx,
-        "cue_files",
-        "status",
-        "ALTER TABLE cue_files ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'",
+        "downloads",
+        "last_seen_in_queue_at",
+        "ALTER TABLE downloads ADD COLUMN last_seen_in_queue_at TEXT",
     )?;
     add_column_if_missing(
         &tx,
-        "cue_files",
-        "message",
-        "ALTER TABLE cue_files ADD COLUMN message TEXT",
+        "downloads",
+        "processing_started_at",
+        "ALTER TABLE downloads ADD COLUMN processing_started_at TEXT",
     )?;
+    add_column_if_missing(
+        &tx,
+        "downloads",
+        "processing_finished_at",
+        "ALTER TABLE downloads ADD COLUMN processing_finished_at TEXT",
+    )?;
+    add_column_if_missing(
+        &tx,
+        "downloads",
+        "cleanup_started_at",
+        "ALTER TABLE downloads ADD COLUMN cleanup_started_at TEXT",
+    )?;
+    add_column_if_missing(
+        &tx,
+        "downloads",
+        "cleanup_finished_at",
+        "ALTER TABLE downloads ADD COLUMN cleanup_finished_at TEXT",
+    )?;
+    add_column_if_missing(&tx, "downloads", "completed_at", "ALTER TABLE downloads ADD COLUMN completed_at TEXT")?;
+    add_column_if_missing(&tx, "downloads", "last_error", "ALTER TABLE downloads ADD COLUMN last_error TEXT")?;
+    add_column_if_missing(&tx, "cue_files", "status", "ALTER TABLE cue_files ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'")?;
+    add_column_if_missing(&tx, "cue_files", "message", "ALTER TABLE cue_files ADD COLUMN message TEXT")?;
     add_column_if_missing(
         &tx,
         "cue_files",
         "updated_at",
         "ALTER TABLE cue_files ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00'",
     )?;
+    add_column_if_missing(&tx, "tracks", "size_bytes", "ALTER TABLE tracks ADD COLUMN size_bytes INTEGER")?;
+    add_column_if_missing(
+        &tx,
+        "tracks",
+        "cleanup_status",
+        "ALTER TABLE tracks ADD COLUMN cleanup_status TEXT NOT NULL DEFAULT 'pending'",
+    )?;
+    add_column_if_missing(&tx, "tracks", "cleanup_message", "ALTER TABLE tracks ADD COLUMN cleanup_message TEXT")?;
+    add_column_if_missing(&tx, "tracks", "deleted_at", "ALTER TABLE tracks ADD COLUMN deleted_at TEXT")?;
+
+    tx.execute(
+        "UPDATE downloads
+         SET created_at = CASE
+                WHEN created_at IS NULL OR created_at = '1970-01-01 00:00:00' THEN COALESCE(updated_at, CURRENT_TIMESTAMP)
+                ELSE created_at
+             END,
+             updated_at = COALESCE(updated_at, CURRENT_TIMESTAMP),
+             first_seen_at = COALESCE(first_seen_at, created_at, updated_at, CURRENT_TIMESTAMP),
+             last_seen_in_queue_at = COALESCE(last_seen_in_queue_at, updated_at)",
+        [],
+    )?;
+
+    if column_exists(&tx, "downloads", "split_complete")? {
+        tx.execute(
+            "UPDATE downloads
+             SET lifecycle_state = CASE
+                 WHEN lifecycle_state IS NOT NULL AND lifecycle_state <> '' THEN lifecycle_state
+                 WHEN split_complete = 1 THEN 'awaiting_import'
+                 WHEN COALESCE(last_error, '') <> '' THEN 'failed'
+                 ELSE 'detected'
+             END",
+            [],
+        )?;
+    } else {
+        tx.execute(
+            "UPDATE downloads
+             SET lifecycle_state = COALESCE(NULLIF(lifecycle_state, ''), 'detected')",
+            [],
+        )?;
+    }
 
     tx.execute(
         "DELETE FROM cue_files
          WHERE rowid NOT IN (
              SELECT MIN(rowid) FROM cue_files GROUP BY download_id, path
+         )",
+        [],
+    )?;
+    tx.execute(
+        "DELETE FROM input_files
+         WHERE rowid NOT IN (
+             SELECT MIN(rowid) FROM input_files GROUP BY download_id, path
          )",
         [],
     )?;
@@ -412,21 +769,21 @@ fn migrate(conn: &mut Connection) -> Result<()> {
         [],
     )?;
     tx.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_input_files_download_path
+         ON input_files(download_id, path)",
+        [],
+    )?;
+    tx.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_tracks_download_path
          ON tracks(download_id, path)",
         [],
     )?;
-    tx.pragma_update(None, "user_version", 1)?;
+    tx.pragma_update(None, "user_version", 2)?;
     tx.commit()?;
     Ok(())
 }
 
-fn add_column_if_missing(
-    conn: &Connection,
-    table: &str,
-    column: &str,
-    statement: &str,
-) -> Result<()> {
+fn add_column_if_missing(conn: &Connection, table: &str, column: &str, statement: &str) -> Result<()> {
     if !column_exists(conn, table, column)? {
         conn.execute(statement, [])?;
     }
@@ -446,19 +803,19 @@ fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
 
     use rusqlite::Connection;
     use tempfile::tempdir;
 
     use super::SqliteDownloadStore;
-    use crate::domain::{CueSheetStatus, TrackedDownload};
+    use crate::domain::{CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack, TrackCleanupStatus, TrackedDownload};
 
     #[test]
-    fn repository_saves_updates_and_deletes_download_graph() {
+    fn repository_persists_history_and_file_snapshots() {
         let tmp = tempdir().unwrap();
         let repo = SqliteDownloadStore::open(tmp.path()).unwrap();
-        let mut download = TrackedDownload::pending(
+        let download = TrackedDownload::pending(
             "download-1".into(),
             "Album".into(),
             "completed".into(),
@@ -467,42 +824,58 @@ mod tests {
         );
 
         repo.upsert_tracked_download_sync(&download).unwrap();
-        download.title = "Album Updated".into();
-        repo.upsert_tracked_download_sync(&download).unwrap();
-
+        repo.mark_download_processing_sync("download-1").unwrap();
         let cue = repo
             .get_or_create_cue_sheet_sync(
                 &download.download_id,
                 Path::new("/downloads/album/album.cue"),
             )
             .unwrap();
-        repo.record_cue_result_sync(
-            &cue,
-            CueSheetStatus::Split,
-            None,
-            &[PathBuf::from("/downloads/album/01.flac")],
+        repo.record_input_file_sync(
+            &download.download_id,
+            Some(&cue.id),
+            Path::new("/downloads/album/album.cue"),
+            InputFileKind::Cue,
+            Some(123),
         )
         .unwrap();
         repo.record_cue_result_sync(
             &cue,
             CueSheetStatus::Split,
             None,
-            &[PathBuf::from("/downloads/album/01.flac")],
+            &[RecordedTrack {
+                path: "/downloads/album/01.flac".into(),
+                size_bytes: Some(456),
+            }],
         )
         .unwrap();
+        repo.mark_download_awaiting_import_sync("download-1").unwrap();
+        let stored = repo.get_tracked_download_sync("download-1").unwrap().unwrap();
+        let track = &stored.cue_sheets[0].tracks[0];
+        repo.record_track_cleanup_sync(
+            "download-1",
+            &track.id,
+            TrackCleanupStatus::Deleted,
+            None,
+        )
+        .unwrap();
+        repo.mark_download_completed_sync("download-1").unwrap();
 
         let downloads = repo.load_tracked_downloads_sync().unwrap();
         assert_eq!(downloads.len(), 1);
-        assert_eq!(downloads[0].title, "Album Updated");
+        assert_eq!(downloads[0].lifecycle_state, DownloadLifecycleState::Completed);
+        assert_eq!(downloads[0].input_files.len(), 1);
         assert_eq!(downloads[0].cue_sheets.len(), 1);
         assert_eq!(downloads[0].cue_sheets[0].tracks.len(), 1);
-
-        repo.delete_download_sync("download-1").unwrap();
-        assert!(repo.load_tracked_downloads_sync().unwrap().is_empty());
+        assert_eq!(downloads[0].cue_sheets[0].tracks[0].size_bytes, Some(456));
+        assert_eq!(
+            downloads[0].cue_sheets[0].tracks[0].cleanup_status,
+            TrackCleanupStatus::Deleted
+        );
     }
 
     #[test]
-    fn migration_adds_missing_columns_without_losing_existing_rows() {
+    fn migration_backfills_lifecycle_state_from_legacy_rows() {
         let tmp = tempdir().unwrap();
         let db_path = tmp.path().join("data.db");
         let conn = Connection::open(&db_path).unwrap();
@@ -513,7 +886,9 @@ mod tests {
                 status TEXT NOT NULL,
                 output_path TEXT NOT NULL,
                 tracked_download_state TEXT NOT NULL,
-                split_complete BOOLEAN NOT NULL DEFAULT FALSE
+                split_complete BOOLEAN NOT NULL DEFAULT FALSE,
+                last_error TEXT,
+                updated_at TEXT NOT NULL DEFAULT '2024-01-01 00:00:00'
             );
             CREATE TABLE cue_files (
                 id TEXT PRIMARY KEY,
@@ -526,11 +901,10 @@ mod tests {
                 cue_file_id TEXT NOT NULL,
                 download_id TEXT NOT NULL
             );
-            INSERT INTO downloads (
-                download_id, title, status, output_path, tracked_download_state, split_complete
-            ) VALUES (
-                'download-1', 'Album', 'completed', '/downloads/album', 'importFailed', 0
-            );",
+            INSERT INTO downloads(download_id, title, status, output_path, tracked_download_state, split_complete, last_error)
+            VALUES
+                ('done', 'Done', 'completed', '/downloads/done', 'importFailed', 1, NULL),
+                ('bad', 'Bad', 'completed', '/downloads/bad', 'importFailed', 0, 'split failed');",
         )
         .unwrap();
         drop(conn);
@@ -538,7 +912,10 @@ mod tests {
         let repo = SqliteDownloadStore::open(tmp.path()).unwrap();
         let downloads = repo.load_tracked_downloads_sync().unwrap();
 
-        assert_eq!(downloads.len(), 1);
-        assert_eq!(downloads[0].download_id, "download-1");
+        assert_eq!(downloads.len(), 2);
+        let done = downloads.iter().find(|download| download.download_id == "done").unwrap();
+        let bad = downloads.iter().find(|download| download.download_id == "bad").unwrap();
+        assert_eq!(done.lifecycle_state, DownloadLifecycleState::AwaitingImport);
+        assert_eq!(bad.lifecycle_state, DownloadLifecycleState::Failed);
     }
 }

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -1,8 +1,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{anyhow, Result};
-use rusqlite::{named_params, params, Connection, OptionalExtension};
+use rusqlite::{named_params, params, params_from_iter, Connection, OptionalExtension};
 use uuid::Uuid;
 
 use crate::application::ports::DownloadStore;
@@ -29,19 +30,21 @@ pub struct DownloadRow {
     pub generated_track_count: usize,
 }
 
+const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
 impl SqliteDownloadStore {
     pub fn open(data_dir: impl AsRef<Path>) -> Result<Self> {
         fs::create_dir_all(data_dir.as_ref())?;
         let db_path = data_dir.as_ref().join("data.db");
         let mut conn = Connection::open(&db_path)?;
-        conn.pragma_update(None, "foreign_keys", "ON")?;
+        configure_connection(&conn)?;
         migrate(&mut conn)?;
         Ok(Self { db_path })
     }
 
     fn connect(&self) -> Result<Connection> {
         let conn = Connection::open(&self.db_path)?;
-        conn.pragma_update(None, "foreign_keys", "ON")?;
+        configure_connection(&conn)?;
         Ok(conn)
     }
 
@@ -158,6 +161,45 @@ impl SqliteDownloadStore {
                 |row| map_download_row(&conn, row),
             )
             .optional()?)
+    }
+
+    fn get_tracked_downloads_sync(&self, download_ids: &[String]) -> Result<Vec<TrackedDownload>> {
+        use std::collections::HashMap;
+
+        if download_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let conn = self.connect()?;
+        let placeholders = std::iter::repeat_n("?", download_ids.len())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let query = format!(
+            "SELECT download_id, title, status, output_path, tracked_download_state,
+                    lifecycle_state, created_at, updated_at, first_seen_at, last_seen_in_queue_at,
+                    processing_started_at, processing_finished_at, cleanup_started_at,
+                    cleanup_finished_at, completed_at, last_error
+             FROM downloads
+             WHERE download_id IN ({placeholders})"
+        );
+        let mut stmt = conn.prepare(&query)?;
+        let rows = stmt.query_map(params_from_iter(download_ids.iter()), |row| {
+            map_download_row(&conn, row)
+        })?;
+
+        let mut by_id = HashMap::new();
+        for row in rows {
+            let download = row?;
+            by_id.insert(download.download_id.clone(), download);
+        }
+
+        let mut downloads = Vec::new();
+        for download_id in download_ids {
+            if let Some(download) = by_id.remove(download_id) {
+                downloads.push(download);
+            }
+        }
+        Ok(downloads)
     }
 
     fn upsert_tracked_download_sync(&self, download: &TrackedDownload) -> Result<()> {
@@ -414,6 +456,14 @@ impl DownloadStore for SqliteDownloadStore {
         let store = self.clone();
         let download_id = download_id.to_owned();
         tokio::task::spawn_blocking(move || store.get_tracked_download_sync(&download_id))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn get_tracked_downloads(&self, download_ids: &[String]) -> Result<Vec<TrackedDownload>> {
+        let store = self.clone();
+        let download_ids = download_ids.to_vec();
+        tokio::task::spawn_blocking(move || store.get_tracked_downloads_sync(&download_ids))
             .await
             .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
@@ -973,6 +1023,12 @@ fn add_column_if_missing(
     Ok(())
 }
 
+fn configure_connection(conn: &Connection) -> Result<()> {
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+    conn.busy_timeout(SQLITE_BUSY_TIMEOUT)?;
+    Ok(())
+}
+
 fn column_exists(conn: &Connection, table: &str, column: &str) -> Result<bool> {
     let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
     let rows = stmt.query_map([], |row| row.get::<_, String>(1))?;
@@ -1209,6 +1265,55 @@ mod tests {
         assert_eq!(row.title, "Album");
         assert_eq!(row.generated_track_count, 1);
         assert_eq!(repo.load_download_row_sync("missing").unwrap(), None);
+    }
+
+    #[test]
+    fn bulk_get_tracked_downloads_preserves_requested_order() {
+        let tmp = tempdir().unwrap();
+        let repo = SqliteDownloadStore::open(tmp.path()).unwrap();
+
+        let first = TrackedDownload::pending(
+            "download-1".into(),
+            "First".into(),
+            "completed".into(),
+            "/downloads/first".into(),
+            "importFailed".into(),
+        );
+        let second = TrackedDownload::pending(
+            "download-2".into(),
+            "Second".into(),
+            "completed".into(),
+            "/downloads/second".into(),
+            "importFailed".into(),
+        );
+
+        repo.upsert_tracked_download_sync(&first).unwrap();
+        repo.upsert_tracked_download_sync(&second).unwrap();
+
+        let downloads = repo
+            .get_tracked_downloads_sync(&[
+                "download-2".to_string(),
+                "missing".to_string(),
+                "download-1".to_string(),
+            ])
+            .unwrap();
+
+        assert_eq!(downloads.len(), 2);
+        assert_eq!(downloads[0].download_id, "download-2");
+        assert_eq!(downloads[1].download_id, "download-1");
+    }
+
+    #[test]
+    fn connections_set_busy_timeout() {
+        let tmp = tempdir().unwrap();
+        let repo = SqliteDownloadStore::open(tmp.path()).unwrap();
+
+        let conn = repo.connect().unwrap();
+        let busy_timeout_ms = conn
+            .query_row("PRAGMA busy_timeout", [], |row| row.get::<_, i64>(0))
+            .unwrap();
+
+        assert_eq!(busy_timeout_ms, super::SQLITE_BUSY_TIMEOUT.as_millis() as i64);
     }
 
     #[test]

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use crate::application::ports::DownloadStore;
 use crate::domain::{
     CueSheet, CueSheetStatus, DownloadLifecycleState, GeneratedTrack, InputFile, InputFileKind,
-    RecordedTrack, TrackCleanupStatus, TrackedDownload,
+    RecordedTrack, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
 };
 
 #[derive(Debug, Clone)]
@@ -435,6 +435,40 @@ impl SqliteDownloadStore {
         tx.commit()?;
         Ok(())
     }
+
+    fn record_track_cleanups_sync(
+        &self,
+        download_id: &str,
+        outcomes: &[TrackCleanupOutcome],
+    ) -> Result<()> {
+        let mut conn = self.connect()?;
+        let tx = conn.transaction()?;
+        for outcome in outcomes {
+            tx.execute(
+                "UPDATE tracks
+                 SET cleanup_status = ?2,
+                     cleanup_message = ?3,
+                     deleted_at = CASE
+                         WHEN ?2 IN ('deleted', 'missing') THEN CURRENT_TIMESTAMP
+                         ELSE NULL
+                     END
+                 WHERE id = ?1",
+                params![
+                    &outcome.track_id,
+                    outcome.status.as_str(),
+                    outcome.message.as_deref()
+                ],
+            )?;
+        }
+        tx.execute(
+            "UPDATE downloads
+             SET updated_at = CURRENT_TIMESTAMP
+             WHERE download_id = ?",
+            [download_id],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
 }
 
 impl DownloadStore for SqliteDownloadStore {
@@ -592,6 +626,21 @@ impl DownloadStore for SqliteDownloadStore {
         .await
         .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
+
+    async fn record_track_cleanups(
+        &self,
+        download_id: &str,
+        outcomes: &[TrackCleanupOutcome],
+    ) -> Result<()> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        let outcomes = outcomes.to_vec();
+        tokio::task::spawn_blocking(move || {
+            store.record_track_cleanups_sync(&download_id, &outcomes)
+        })
+        .await
+        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
 }
 
 fn map_download_row(
@@ -609,7 +658,7 @@ fn map_download_row(
         status: row.get(2)?,
         output_path: row.get(3)?,
         tracked_download_state: row.get(4)?,
-        lifecycle_state: DownloadLifecycleState::from_db(row.get::<_, String>(5)?.as_str()),
+        lifecycle_state: lifecycle_state_from_row(row, 5)?,
         created_at: row.get(6)?,
         updated_at: row.get(7)?,
         first_seen_at: row.get(8)?,
@@ -631,7 +680,7 @@ fn map_download_history_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Downloa
         status: row.get(2)?,
         output_path: row.get(3)?,
         tracked_download_state: row.get(4)?,
-        lifecycle_state: DownloadLifecycleState::from_db(row.get::<_, String>(5)?.as_str()),
+        lifecycle_state: lifecycle_state_from_row(row, 5)?,
         updated_at: row.get(6)?,
         completed_at: row.get(7)?,
         generated_track_count: row.get::<_, i64>(8)? as usize,
@@ -647,7 +696,7 @@ fn map_download_summary_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Tracked
         status: row.get(2)?,
         output_path: row.get(3)?,
         tracked_download_state: row.get(4)?,
-        lifecycle_state: DownloadLifecycleState::from_db(row.get::<_, String>(5)?.as_str()),
+        lifecycle_state: lifecycle_state_from_row(row, 5)?,
         created_at: row.get(6)?,
         updated_at: row.get(7)?,
         first_seen_at: row.get(8)?,
@@ -660,6 +709,17 @@ fn map_download_summary_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Tracked
         generated_track_count: row.get::<_, i64>(16)? as usize,
         last_error: row.get(15)?,
     })
+}
+
+fn lifecycle_state_from_row(
+    row: &rusqlite::Row<'_>,
+    index: usize,
+) -> rusqlite::Result<DownloadLifecycleState> {
+    Ok(DownloadLifecycleState::from_db(
+        row.get::<_, Option<String>>(index)?
+            .as_deref()
+            .unwrap_or("detected"),
+    ))
 }
 
 fn cue_sheets_for(conn: &Connection, download_id: &str) -> rusqlite::Result<Vec<CueSheet>> {
@@ -1049,8 +1109,8 @@ mod tests {
 
     use super::SqliteDownloadStore;
     use crate::domain::{
-        CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack, TrackCleanupStatus,
-        TrackedDownload,
+        CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack, TrackCleanupOutcome,
+        TrackCleanupStatus, TrackedDownload,
     };
 
     #[test]
@@ -1314,6 +1374,106 @@ mod tests {
             .unwrap();
 
         assert_eq!(busy_timeout_ms, super::SQLITE_BUSY_TIMEOUT.as_millis() as i64);
+    }
+
+    #[test]
+    fn record_track_cleanups_updates_multiple_tracks_in_one_call() {
+        let tmp = tempdir().unwrap();
+        let repo = SqliteDownloadStore::open(tmp.path()).unwrap();
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Album".into(),
+            "completed".into(),
+            "/downloads/album".into(),
+            "importFailed".into(),
+        );
+
+        repo.upsert_tracked_download_sync(&download).unwrap();
+        let cue = repo
+            .get_or_create_cue_sheet_sync(
+                &download.download_id,
+                Path::new("/downloads/album/album.cue"),
+            )
+            .unwrap();
+        repo.record_cue_result_sync(
+            &cue,
+            CueSheetStatus::Split,
+            None,
+            &[
+                RecordedTrack {
+                    path: "/downloads/album/01.flac".into(),
+                    size_bytes: Some(111),
+                },
+                RecordedTrack {
+                    path: "/downloads/album/02.flac".into(),
+                    size_bytes: Some(222),
+                },
+            ],
+        )
+        .unwrap();
+
+        let stored = repo
+            .get_tracked_download_sync("download-1")
+            .unwrap()
+            .unwrap();
+        let outcomes = stored.cue_sheets[0]
+            .tracks
+            .iter()
+            .map(|track| TrackCleanupOutcome {
+                track_id: track.id.clone(),
+                status: TrackCleanupStatus::Deleted,
+                message: None,
+            })
+            .collect::<Vec<_>>();
+
+        repo.record_track_cleanups_sync("download-1", &outcomes)
+            .unwrap();
+
+        let refreshed = repo
+            .get_tracked_download_sync("download-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(refreshed.cue_sheets[0].tracks.len(), 2);
+        assert!(refreshed.cue_sheets[0]
+            .tracks
+            .iter()
+            .all(|track| track.cleanup_status == TrackCleanupStatus::Deleted));
+    }
+
+    #[test]
+    fn null_lifecycle_state_defaults_to_detected() {
+        let tmp = tempdir().unwrap();
+        let repo = SqliteDownloadStore::open(tmp.path()).unwrap();
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Album".into(),
+            "completed".into(),
+            "/downloads/album".into(),
+            "importFailed".into(),
+        );
+        repo.upsert_tracked_download_sync(&download).unwrap();
+        let conn = Connection::open(&repo.db_path).unwrap();
+        conn.execute(
+            "UPDATE downloads SET lifecycle_state = NULL WHERE download_id = ?",
+            ["download-1"],
+        )
+        .unwrap();
+        drop(conn);
+
+        let summary = repo
+            .load_tracked_download_summaries_sync()
+            .unwrap()
+            .pop()
+            .unwrap();
+        let full = repo
+            .get_tracked_download_sync("download-1")
+            .unwrap()
+            .unwrap();
+        let row = repo.load_download_row_sync("download-1").unwrap().unwrap();
+
+        assert_eq!(summary.lifecycle_state, DownloadLifecycleState::Detected);
+        assert_eq!(full.lifecycle_state, DownloadLifecycleState::Detected);
+        assert_eq!(row.lifecycle_state, DownloadLifecycleState::Detected);
     }
 
     #[test]

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -67,16 +67,19 @@ impl SqliteDownloadStore {
     fn load_tracked_download_summaries_sync(&self) -> Result<Vec<TrackedDownload>> {
         let conn = self.connect()?;
         let mut stmt = conn.prepare(
-            "SELECT download_id, title, status, output_path, tracked_download_state,
-                    lifecycle_state, created_at, updated_at, first_seen_at, last_seen_in_queue_at,
-                    processing_started_at, processing_finished_at, cleanup_started_at,
-                    cleanup_finished_at, completed_at, last_error,
-                    (SELECT COUNT(t.id)
-                     FROM cue_files c
-                     LEFT JOIN tracks t ON t.cue_file_id = c.id
-                     WHERE c.download_id = downloads.download_id) AS generated_track_count
-             FROM downloads
-             ORDER BY updated_at DESC, download_id DESC",
+            "SELECT d.download_id, d.title, d.status, d.output_path, d.tracked_download_state,
+                    d.lifecycle_state, d.created_at, d.updated_at, d.first_seen_at,
+                    d.last_seen_in_queue_at, d.processing_started_at, d.processing_finished_at,
+                    d.cleanup_started_at, d.cleanup_finished_at, d.completed_at, d.last_error,
+                    COUNT(t.id) AS generated_track_count
+             FROM downloads d
+             LEFT JOIN cue_files c ON c.download_id = d.download_id
+             LEFT JOIN tracks t ON t.cue_file_id = c.id
+             GROUP BY d.download_id, d.title, d.status, d.output_path, d.tracked_download_state,
+                      d.lifecycle_state, d.created_at, d.updated_at, d.first_seen_at,
+                      d.last_seen_in_queue_at, d.processing_started_at, d.processing_finished_at,
+                      d.cleanup_started_at, d.cleanup_finished_at, d.completed_at, d.last_error
+             ORDER BY d.updated_at DESC, d.download_id DESC",
         )?;
         let rows = stmt.query_map([], map_download_summary_row)?;
 
@@ -99,19 +102,7 @@ impl SqliteDownloadStore {
                       d.lifecycle_state, d.updated_at, d.completed_at
              ORDER BY d.updated_at DESC, d.download_id DESC",
         )?;
-        let rows = stmt.query_map([], |row| {
-            Ok(DownloadRow {
-                download_id: row.get(0)?,
-                title: row.get(1)?,
-                status: row.get(2)?,
-                output_path: row.get(3)?,
-                tracked_download_state: row.get(4)?,
-                lifecycle_state: DownloadLifecycleState::from_db(row.get::<_, String>(5)?.as_str()),
-                updated_at: row.get(6)?,
-                completed_at: row.get(7)?,
-                generated_track_count: row.get::<_, i64>(8)? as usize,
-            })
-        })?;
+        let rows = stmt.query_map([], map_download_history_row)?;
 
         let mut download_rows = Vec::new();
         for row in rows {
@@ -123,6 +114,32 @@ impl SqliteDownloadStore {
     pub async fn load_download_rows(&self) -> Result<Vec<DownloadRow>> {
         let store = self.clone();
         tokio::task::spawn_blocking(move || store.load_download_rows_sync())
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    fn load_download_row_sync(&self, download_id: &str) -> Result<Option<DownloadRow>> {
+        let conn = self.connect()?;
+        Ok(conn
+            .query_row(
+                "SELECT d.download_id, d.title, d.status, d.output_path, d.tracked_download_state,
+                        d.lifecycle_state, d.updated_at, d.completed_at, COUNT(t.id) AS generated_track_count
+                 FROM downloads d
+                 LEFT JOIN cue_files c ON c.download_id = d.download_id
+                 LEFT JOIN tracks t ON t.cue_file_id = c.id
+                 WHERE d.download_id = ?
+                 GROUP BY d.download_id, d.title, d.status, d.output_path, d.tracked_download_state,
+                          d.lifecycle_state, d.updated_at, d.completed_at",
+                [download_id],
+                map_download_history_row,
+            )
+            .optional()?)
+    }
+
+    pub async fn load_download_row(&self, download_id: &str) -> Result<Option<DownloadRow>> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        tokio::task::spawn_blocking(move || store.load_download_row_sync(&download_id))
             .await
             .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
@@ -195,7 +212,7 @@ impl SqliteDownloadStore {
         conn.execute(
             "UPDATE downloads
              SET lifecycle_state = 'awaiting_import',
-                 processing_finished_at = CURRENT_TIMESTAMP,
+                 processing_finished_at = COALESCE(processing_finished_at, CURRENT_TIMESTAMP),
                  last_error = NULL,
                  updated_at = CURRENT_TIMESTAMP
              WHERE download_id = ?",
@@ -329,7 +346,10 @@ impl SqliteDownloadStore {
                  VALUES (?1, ?2, ?3, ?4, ?5, 'pending', NULL, NULL)
                  ON CONFLICT(download_id, path) DO UPDATE SET
                     cue_file_id = excluded.cue_file_id,
-                    size_bytes = excluded.size_bytes",
+                    size_bytes = excluded.size_bytes,
+                    cleanup_status = excluded.cleanup_status,
+                    cleanup_message = excluded.cleanup_message,
+                    deleted_at = excluded.deleted_at",
                 params![
                     Uuid::new_v4().to_string(),
                     &track.path,
@@ -551,6 +571,20 @@ fn map_download_row(
         completed_at: row.get(14)?,
         generated_track_count,
         last_error: row.get(15)?,
+    })
+}
+
+fn map_download_history_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DownloadRow> {
+    Ok(DownloadRow {
+        download_id: row.get(0)?,
+        title: row.get(1)?,
+        status: row.get(2)?,
+        output_path: row.get(3)?,
+        tracked_download_state: row.get(4)?,
+        lifecycle_state: DownloadLifecycleState::from_db(row.get::<_, String>(5)?.as_str()),
+        updated_at: row.get(6)?,
+        completed_at: row.get(7)?,
+        generated_track_count: row.get::<_, i64>(8)? as usize,
     })
 }
 
@@ -1026,6 +1060,155 @@ mod tests {
             downloads[0].cue_sheets[0].tracks[0].cleanup_status,
             TrackCleanupStatus::Deleted
         );
+    }
+
+    #[test]
+    fn awaiting_import_preserves_first_processing_finished_timestamp() {
+        let tmp = tempdir().unwrap();
+        let repo = SqliteDownloadStore::open(tmp.path()).unwrap();
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Album".into(),
+            "completed".into(),
+            "/downloads/album".into(),
+            "importFailed".into(),
+        );
+
+        repo.upsert_tracked_download_sync(&download).unwrap();
+        repo.mark_download_awaiting_import_sync("download-1").unwrap();
+
+        let conn = Connection::open(&repo.db_path).unwrap();
+        conn.execute(
+            "UPDATE downloads
+             SET processing_finished_at = '2001-02-03 04:05:06'
+             WHERE download_id = ?",
+            ["download-1"],
+        )
+        .unwrap();
+        drop(conn);
+
+        repo.mark_download_awaiting_import_sync("download-1").unwrap();
+
+        let stored = repo
+            .get_tracked_download_sync("download-1")
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored.processing_finished_at.as_deref(),
+            Some("2001-02-03 04:05:06")
+        );
+    }
+
+    #[test]
+    fn re_recorded_track_resets_stale_cleanup_state() {
+        let tmp = tempdir().unwrap();
+        let repo = SqliteDownloadStore::open(tmp.path()).unwrap();
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Album".into(),
+            "completed".into(),
+            "/downloads/album".into(),
+            "importFailed".into(),
+        );
+
+        repo.upsert_tracked_download_sync(&download).unwrap();
+        let cue = repo
+            .get_or_create_cue_sheet_sync(
+                &download.download_id,
+                Path::new("/downloads/album/album.cue"),
+            )
+            .unwrap();
+        repo.record_cue_result_sync(
+            &cue,
+            CueSheetStatus::Split,
+            None,
+            &[RecordedTrack {
+                path: "/downloads/album/01.flac".into(),
+                size_bytes: Some(456),
+            }],
+        )
+        .unwrap();
+
+        let stored = repo
+            .get_tracked_download_sync("download-1")
+            .unwrap()
+            .unwrap();
+        let track = &stored.cue_sheets[0].tracks[0];
+        repo.record_track_cleanup_sync(
+            "download-1",
+            &track.id,
+            TrackCleanupStatus::Deleted,
+            Some("already removed"),
+        )
+        .unwrap();
+
+        repo.record_cue_result_sync(
+            &cue,
+            CueSheetStatus::Split,
+            None,
+            &[RecordedTrack {
+                path: "/downloads/album/01.flac".into(),
+                size_bytes: Some(789),
+            }],
+        )
+        .unwrap();
+
+        let refreshed = repo
+            .get_tracked_download_sync("download-1")
+            .unwrap()
+            .unwrap();
+        let track = &refreshed.cue_sheets[0].tracks[0];
+        assert_eq!(track.size_bytes, Some(789));
+        assert_eq!(track.cleanup_status, TrackCleanupStatus::Pending);
+        assert_eq!(track.cleanup_message, None);
+        assert_eq!(track.deleted_at, None);
+    }
+
+    #[test]
+    fn load_download_row_fetches_only_requested_history_row() {
+        let tmp = tempdir().unwrap();
+        let repo = SqliteDownloadStore::open(tmp.path()).unwrap();
+
+        let album = TrackedDownload::pending(
+            "download-1".into(),
+            "Album".into(),
+            "completed".into(),
+            "/downloads/album".into(),
+            "importFailed".into(),
+        );
+        let single = TrackedDownload::pending(
+            "download-2".into(),
+            "Single".into(),
+            "completed".into(),
+            "/downloads/single".into(),
+            "importFailed".into(),
+        );
+
+        repo.upsert_tracked_download_sync(&album).unwrap();
+        repo.upsert_tracked_download_sync(&single).unwrap();
+
+        let cue = repo
+            .get_or_create_cue_sheet_sync(
+                &album.download_id,
+                Path::new("/downloads/album/album.cue"),
+            )
+            .unwrap();
+        repo.record_cue_result_sync(
+            &cue,
+            CueSheetStatus::Split,
+            None,
+            &[RecordedTrack {
+                path: "/downloads/album/01.flac".into(),
+                size_bytes: Some(456),
+            }],
+        )
+        .unwrap();
+
+        let row = repo.load_download_row_sync("download-1").unwrap().unwrap();
+        assert_eq!(row.download_id, "download-1");
+        assert_eq!(row.title, "Album");
+        assert_eq!(row.generated_track_count, 1);
+        assert_eq!(repo.load_download_row_sync("missing").unwrap(), None);
     }
 
     #[test]

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -72,7 +72,7 @@ impl SqliteDownloadStore {
 
     fn get_tracked_download_sync(&self, download_id: &str) -> Result<Option<TrackedDownload>> {
         let conn = self.connect()?;
-        conn.query_row(
+        Ok(conn.query_row(
             "SELECT download_id, title, status, output_path, tracked_download_state,
                     lifecycle_state, created_at, updated_at, first_seen_at, last_seen_in_queue_at,
                     processing_started_at, processing_finished_at, cleanup_started_at,
@@ -82,8 +82,7 @@ impl SqliteDownloadStore {
             [download_id],
             |row| map_download_row(&conn, row),
         )
-        .optional()
-        .map_err(Into::into)
+        .optional()?)
     }
 
     fn upsert_tracked_download_sync(&self, download: &TrackedDownload) -> Result<()> {
@@ -115,18 +114,6 @@ impl SqliteDownloadStore {
                 ":lifecycle_state": download.lifecycle_state.as_str(),
                 ":last_error": &download.last_error,
             },
-        )?;
-        Ok(())
-    }
-
-    fn touch_download_queue_presence_sync(&self, download_id: &str) -> Result<()> {
-        let conn = self.connect()?;
-        conn.execute(
-            "UPDATE downloads
-             SET last_seen_in_queue_at = CURRENT_TIMESTAMP,
-                 updated_at = CURRENT_TIMESTAMP
-             WHERE download_id = ?",
-            [download_id],
         )?;
         Ok(())
     }
@@ -357,14 +344,6 @@ impl DownloadStore for SqliteDownloadStore {
         let store = self.clone();
         let download = download.clone();
         tokio::task::spawn_blocking(move || store.upsert_tracked_download_sync(&download))
-            .await
-            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
-    }
-
-    async fn touch_download_queue_presence(&self, download_id: &str) -> Result<()> {
-        let store = self.clone();
-        let download_id = download_id.to_owned();
-        tokio::task::spawn_blocking(move || store.touch_download_queue_presence_sync(&download_id))
             .await
             .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
@@ -607,7 +586,6 @@ fn cue_sheet_by_download_and_path(
         },
     )
     .optional()
-    .map_err(Into::into)
 }
 
 fn tracks_for(conn: &Connection, cue_sheet_id: &str) -> Result<Vec<GeneratedTrack>, rusqlite::Error> {

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -70,7 +70,11 @@ impl SqliteDownloadStore {
             "SELECT download_id, title, status, output_path, tracked_download_state,
                     lifecycle_state, created_at, updated_at, first_seen_at, last_seen_in_queue_at,
                     processing_started_at, processing_finished_at, cleanup_started_at,
-                    cleanup_finished_at, completed_at, last_error
+                    cleanup_finished_at, completed_at, last_error,
+                    (SELECT COUNT(t.id)
+                     FROM cue_files c
+                     LEFT JOIN tracks t ON t.cue_file_id = c.id
+                     WHERE c.download_id = downloads.download_id) AS generated_track_count
              FROM downloads
              ORDER BY updated_at DESC, download_id DESC",
         )?;
@@ -517,9 +521,11 @@ impl DownloadStore for SqliteDownloadStore {
 
 fn map_download_row(conn: &Connection, row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedDownload> {
     let download_id: String = row.get(0)?;
+    let cue_sheets = cue_sheets_for(conn, &download_id)?;
+    let generated_track_count = cue_sheets.iter().map(|cue| cue.tracks.len()).sum();
     Ok(TrackedDownload {
         input_files: input_files_for(conn, &download_id)?,
-        cue_sheets: cue_sheets_for(conn, &download_id)?,
+        cue_sheets,
         download_id,
         title: row.get(1)?,
         status: row.get(2)?,
@@ -535,6 +541,7 @@ fn map_download_row(conn: &Connection, row: &rusqlite::Row<'_>) -> rusqlite::Res
         cleanup_started_at: row.get(12)?,
         cleanup_finished_at: row.get(13)?,
         completed_at: row.get(14)?,
+        generated_track_count,
         last_error: row.get(15)?,
     })
 }
@@ -558,6 +565,7 @@ fn map_download_summary_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Tracked
         cleanup_started_at: row.get(12)?,
         cleanup_finished_at: row.get(13)?,
         completed_at: row.get(14)?,
+        generated_track_count: row.get::<_, i64>(16)? as usize,
         last_error: row.get(15)?,
     })
 }

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -129,17 +129,18 @@ impl SqliteDownloadStore {
 
     fn get_tracked_download_sync(&self, download_id: &str) -> Result<Option<TrackedDownload>> {
         let conn = self.connect()?;
-        Ok(conn.query_row(
-            "SELECT download_id, title, status, output_path, tracked_download_state,
+        Ok(conn
+            .query_row(
+                "SELECT download_id, title, status, output_path, tracked_download_state,
                     lifecycle_state, created_at, updated_at, first_seen_at, last_seen_in_queue_at,
                     processing_started_at, processing_finished_at, cleanup_started_at,
                     cleanup_finished_at, completed_at, last_error
              FROM downloads
              WHERE download_id = ?",
-            [download_id],
-            |row| map_download_row(&conn, row),
-        )
-        .optional()?)
+                [download_id],
+                |row| map_download_row(&conn, row),
+            )
+            .optional()?)
     }
 
     fn upsert_tracked_download_sync(&self, download: &TrackedDownload) -> Result<()> {
@@ -437,7 +438,11 @@ impl DownloadStore for SqliteDownloadStore {
             .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
 
-    async fn mark_download_failed(&self, download_id: &str, last_error: Option<&str>) -> Result<()> {
+    async fn mark_download_failed(
+        &self,
+        download_id: &str,
+        last_error: Option<&str>,
+    ) -> Result<()> {
         let store = self.clone();
         let download_id = download_id.to_owned();
         let last_error = last_error.map(str::to_owned);
@@ -519,7 +524,10 @@ impl DownloadStore for SqliteDownloadStore {
     }
 }
 
-fn map_download_row(conn: &Connection, row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedDownload> {
+fn map_download_row(
+    conn: &Connection,
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<TrackedDownload> {
     let download_id: String = row.get(0)?;
     let cue_sheets = cue_sheets_for(conn, &download_id)?;
     let generated_track_count = cue_sheets.iter().map(|cue| cue.tracks.len()).sum();
@@ -649,7 +657,10 @@ fn cue_sheet_by_download_and_path(
     .optional()
 }
 
-fn tracks_for(conn: &Connection, cue_sheet_id: &str) -> Result<Vec<GeneratedTrack>, rusqlite::Error> {
+fn tracks_for(
+    conn: &Connection,
+    cue_sheet_id: &str,
+) -> Result<Vec<GeneratedTrack>, rusqlite::Error> {
     let mut stmt = conn.prepare(
         "SELECT id, cue_file_id, download_id, path, size_bytes, cleanup_status, cleanup_message, deleted_at
          FROM tracks
@@ -735,7 +746,12 @@ fn migrate(conn: &mut Connection) -> Result<()> {
         );",
     )?;
 
-    add_column_if_missing(&tx, "downloads", "lifecycle_state", "ALTER TABLE downloads ADD COLUMN lifecycle_state TEXT")?;
+    add_column_if_missing(
+        &tx,
+        "downloads",
+        "lifecycle_state",
+        "ALTER TABLE downloads ADD COLUMN lifecycle_state TEXT",
+    )?;
     add_column_if_missing(
         &tx,
         "downloads",
@@ -748,7 +764,12 @@ fn migrate(conn: &mut Connection) -> Result<()> {
         "updated_at",
         "ALTER TABLE downloads ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00'",
     )?;
-    add_column_if_missing(&tx, "downloads", "first_seen_at", "ALTER TABLE downloads ADD COLUMN first_seen_at TEXT")?;
+    add_column_if_missing(
+        &tx,
+        "downloads",
+        "first_seen_at",
+        "ALTER TABLE downloads ADD COLUMN first_seen_at TEXT",
+    )?;
     add_column_if_missing(
         &tx,
         "downloads",
@@ -779,25 +800,60 @@ fn migrate(conn: &mut Connection) -> Result<()> {
         "cleanup_finished_at",
         "ALTER TABLE downloads ADD COLUMN cleanup_finished_at TEXT",
     )?;
-    add_column_if_missing(&tx, "downloads", "completed_at", "ALTER TABLE downloads ADD COLUMN completed_at TEXT")?;
-    add_column_if_missing(&tx, "downloads", "last_error", "ALTER TABLE downloads ADD COLUMN last_error TEXT")?;
-    add_column_if_missing(&tx, "cue_files", "status", "ALTER TABLE cue_files ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'")?;
-    add_column_if_missing(&tx, "cue_files", "message", "ALTER TABLE cue_files ADD COLUMN message TEXT")?;
+    add_column_if_missing(
+        &tx,
+        "downloads",
+        "completed_at",
+        "ALTER TABLE downloads ADD COLUMN completed_at TEXT",
+    )?;
+    add_column_if_missing(
+        &tx,
+        "downloads",
+        "last_error",
+        "ALTER TABLE downloads ADD COLUMN last_error TEXT",
+    )?;
+    add_column_if_missing(
+        &tx,
+        "cue_files",
+        "status",
+        "ALTER TABLE cue_files ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'",
+    )?;
+    add_column_if_missing(
+        &tx,
+        "cue_files",
+        "message",
+        "ALTER TABLE cue_files ADD COLUMN message TEXT",
+    )?;
     add_column_if_missing(
         &tx,
         "cue_files",
         "updated_at",
         "ALTER TABLE cue_files ADD COLUMN updated_at TEXT NOT NULL DEFAULT '1970-01-01 00:00:00'",
     )?;
-    add_column_if_missing(&tx, "tracks", "size_bytes", "ALTER TABLE tracks ADD COLUMN size_bytes INTEGER")?;
+    add_column_if_missing(
+        &tx,
+        "tracks",
+        "size_bytes",
+        "ALTER TABLE tracks ADD COLUMN size_bytes INTEGER",
+    )?;
     add_column_if_missing(
         &tx,
         "tracks",
         "cleanup_status",
         "ALTER TABLE tracks ADD COLUMN cleanup_status TEXT NOT NULL DEFAULT 'pending'",
     )?;
-    add_column_if_missing(&tx, "tracks", "cleanup_message", "ALTER TABLE tracks ADD COLUMN cleanup_message TEXT")?;
-    add_column_if_missing(&tx, "tracks", "deleted_at", "ALTER TABLE tracks ADD COLUMN deleted_at TEXT")?;
+    add_column_if_missing(
+        &tx,
+        "tracks",
+        "cleanup_message",
+        "ALTER TABLE tracks ADD COLUMN cleanup_message TEXT",
+    )?;
+    add_column_if_missing(
+        &tx,
+        "tracks",
+        "deleted_at",
+        "ALTER TABLE tracks ADD COLUMN deleted_at TEXT",
+    )?;
 
     tx.execute(
         "UPDATE downloads
@@ -871,7 +927,12 @@ fn migrate(conn: &mut Connection) -> Result<()> {
     Ok(())
 }
 
-fn add_column_if_missing(conn: &Connection, table: &str, column: &str, statement: &str) -> Result<()> {
+fn add_column_if_missing(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    statement: &str,
+) -> Result<()> {
     if !column_exists(conn, table, column)? {
         conn.execute(statement, [])?;
     }
@@ -897,7 +958,10 @@ mod tests {
     use tempfile::tempdir;
 
     use super::SqliteDownloadStore;
-    use crate::domain::{CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack, TrackCleanupStatus, TrackedDownload};
+    use crate::domain::{
+        CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack, TrackCleanupStatus,
+        TrackedDownload,
+    };
 
     #[test]
     fn repository_persists_history_and_file_snapshots() {
@@ -937,21 +1001,23 @@ mod tests {
             }],
         )
         .unwrap();
-        repo.mark_download_awaiting_import_sync("download-1").unwrap();
-        let stored = repo.get_tracked_download_sync("download-1").unwrap().unwrap();
+        repo.mark_download_awaiting_import_sync("download-1")
+            .unwrap();
+        let stored = repo
+            .get_tracked_download_sync("download-1")
+            .unwrap()
+            .unwrap();
         let track = &stored.cue_sheets[0].tracks[0];
-        repo.record_track_cleanup_sync(
-            "download-1",
-            &track.id,
-            TrackCleanupStatus::Deleted,
-            None,
-        )
-        .unwrap();
+        repo.record_track_cleanup_sync("download-1", &track.id, TrackCleanupStatus::Deleted, None)
+            .unwrap();
         repo.mark_download_completed_sync("download-1").unwrap();
 
         let downloads = repo.load_tracked_downloads_sync().unwrap();
         assert_eq!(downloads.len(), 1);
-        assert_eq!(downloads[0].lifecycle_state, DownloadLifecycleState::Completed);
+        assert_eq!(
+            downloads[0].lifecycle_state,
+            DownloadLifecycleState::Completed
+        );
         assert_eq!(downloads[0].input_files.len(), 1);
         assert_eq!(downloads[0].cue_sheets.len(), 1);
         assert_eq!(downloads[0].cue_sheets[0].tracks.len(), 1);
@@ -1001,8 +1067,14 @@ mod tests {
         let downloads = repo.load_tracked_downloads_sync().unwrap();
 
         assert_eq!(downloads.len(), 2);
-        let done = downloads.iter().find(|download| download.download_id == "done").unwrap();
-        let bad = downloads.iter().find(|download| download.download_id == "bad").unwrap();
+        let done = downloads
+            .iter()
+            .find(|download| download.download_id == "done")
+            .unwrap();
+        let bad = downloads
+            .iter()
+            .find(|download| download.download_id == "bad")
+            .unwrap();
         assert_eq!(done.lifecycle_state, DownloadLifecycleState::AwaitingImport);
         assert_eq!(bad.lifecycle_state, DownloadLifecycleState::Failed);
     }

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -51,6 +51,25 @@ impl SqliteDownloadStore {
         Ok(downloads)
     }
 
+    fn load_tracked_download_summaries_sync(&self) -> Result<Vec<TrackedDownload>> {
+        let conn = self.connect()?;
+        let mut stmt = conn.prepare(
+            "SELECT download_id, title, status, output_path, tracked_download_state,
+                    lifecycle_state, created_at, updated_at, first_seen_at, last_seen_in_queue_at,
+                    processing_started_at, processing_finished_at, cleanup_started_at,
+                    cleanup_finished_at, completed_at, last_error
+             FROM downloads
+             ORDER BY updated_at DESC, download_id DESC",
+        )?;
+        let rows = stmt.query_map([], map_download_summary_row)?;
+
+        let mut downloads = Vec::new();
+        for row in rows {
+            downloads.push(row?);
+        }
+        Ok(downloads)
+    }
+
     fn get_tracked_download_sync(&self, download_id: &str) -> Result<Option<TrackedDownload>> {
         let conn = self.connect()?;
         conn.query_row(
@@ -319,6 +338,13 @@ impl DownloadStore for SqliteDownloadStore {
             .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
 
+    async fn load_tracked_download_summaries(&self) -> Result<Vec<TrackedDownload>> {
+        let store = self.clone();
+        tokio::task::spawn_blocking(move || store.load_tracked_download_summaries_sync())
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
     async fn get_tracked_download(&self, download_id: &str) -> Result<Option<TrackedDownload>> {
         let store = self.clone();
         let download_id = download_id.to_owned();
@@ -463,6 +489,29 @@ fn map_download_row(conn: &Connection, row: &rusqlite::Row<'_>) -> rusqlite::Res
         input_files: input_files_for(conn, &download_id)?,
         cue_sheets: cue_sheets_for(conn, &download_id)?,
         download_id,
+        title: row.get(1)?,
+        status: row.get(2)?,
+        output_path: row.get(3)?,
+        tracked_download_state: row.get(4)?,
+        lifecycle_state: DownloadLifecycleState::from_db(row.get::<_, String>(5)?.as_str()),
+        created_at: row.get(6)?,
+        updated_at: row.get(7)?,
+        first_seen_at: row.get(8)?,
+        last_seen_in_queue_at: row.get(9)?,
+        processing_started_at: row.get(10)?,
+        processing_finished_at: row.get(11)?,
+        cleanup_started_at: row.get(12)?,
+        cleanup_finished_at: row.get(13)?,
+        completed_at: row.get(14)?,
+        last_error: row.get(15)?,
+    })
+}
+
+fn map_download_summary_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedDownload> {
+    Ok(TrackedDownload {
+        input_files: Vec::new(),
+        cue_sheets: Vec::new(),
+        download_id: row.get(0)?,
         title: row.get(1)?,
         status: row.get(2)?,
         output_path: row.get(3)?,

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -16,6 +16,19 @@ pub struct SqliteDownloadStore {
     db_path: PathBuf,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DownloadRow {
+    pub download_id: String,
+    pub title: String,
+    pub status: String,
+    pub output_path: String,
+    pub tracked_download_state: String,
+    pub lifecycle_state: DownloadLifecycleState,
+    pub updated_at: String,
+    pub completed_at: Option<String>,
+    pub generated_track_count: usize,
+}
+
 impl SqliteDownloadStore {
     pub fn open(data_dir: impl AsRef<Path>) -> Result<Self> {
         fs::create_dir_all(data_dir.as_ref())?;
@@ -68,6 +81,46 @@ impl SqliteDownloadStore {
             downloads.push(row?);
         }
         Ok(downloads)
+    }
+
+    fn load_download_rows_sync(&self) -> Result<Vec<DownloadRow>> {
+        let conn = self.connect()?;
+        let mut stmt = conn.prepare(
+            "SELECT d.download_id, d.title, d.status, d.output_path, d.tracked_download_state,
+                    d.lifecycle_state, d.updated_at, d.completed_at, COUNT(t.id) AS generated_track_count
+             FROM downloads d
+             LEFT JOIN cue_files c ON c.download_id = d.download_id
+             LEFT JOIN tracks t ON t.cue_file_id = c.id
+             GROUP BY d.download_id, d.title, d.status, d.output_path, d.tracked_download_state,
+                      d.lifecycle_state, d.updated_at, d.completed_at
+             ORDER BY d.updated_at DESC, d.download_id DESC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(DownloadRow {
+                download_id: row.get(0)?,
+                title: row.get(1)?,
+                status: row.get(2)?,
+                output_path: row.get(3)?,
+                tracked_download_state: row.get(4)?,
+                lifecycle_state: DownloadLifecycleState::from_db(row.get::<_, String>(5)?.as_str()),
+                updated_at: row.get(6)?,
+                completed_at: row.get(7)?,
+                generated_track_count: row.get::<_, i64>(8)? as usize,
+            })
+        })?;
+
+        let mut download_rows = Vec::new();
+        for row in rows {
+            download_rows.push(row?);
+        }
+        Ok(download_rows)
+    }
+
+    pub async fn load_download_rows(&self) -> Result<Vec<DownloadRow>> {
+        let store = self.clone();
+        tokio::task::spawn_blocking(move || store.load_download_rows_sync())
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
 
     fn get_tracked_download_sync(&self, download_id: &str) -> Result<Option<TrackedDownload>> {

--- a/src/adapters/web.rs
+++ b/src/adapters/web.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use maud::{DOCTYPE, Markup, PreEscaped, html};
 
-use crate::adapters::sqlite_download_store::SqliteDownloadStore;
+use crate::adapters::sqlite_download_store::{DownloadRow, SqliteDownloadStore};
 use crate::application::ports::DownloadStore;
 use crate::domain::{
     CueSheet, CueSheetStatus, DownloadLifecycleState, GeneratedTrack, InputFile, InputFileKind,
@@ -26,6 +26,7 @@ pub fn router(store: SqliteDownloadStore) -> Router {
         .route("/downloads/{download_id}", get(download_detail))
         .route("/downloads/{download_id}/content", get(download_detail_content))
         .route("/downloads/{download_id}/row", get(download_row_route))
+        .route("/downloads/rows", get(download_rows_route))
         .with_state(WebState { store })
 }
 
@@ -34,7 +35,7 @@ async fn healthz() -> impl IntoResponse {
 }
 
 async fn index(State(state): State<WebState>) -> Response {
-    match state.store.load_tracked_downloads().await {
+    match state.store.load_download_rows().await {
         Ok(downloads) => Html(page(
             "Splittarr",
             html! {
@@ -79,12 +80,28 @@ async fn download_row_route(
     State(state): State<WebState>,
     Path(download_id): Path<String>,
 ) -> impl IntoResponse {
-    match state.store.get_tracked_download(&download_id).await {
-        Ok(Some(download)) => download_row(&download).into_response(),
-        Ok(None) => (StatusCode::NOT_FOUND, "download not found").into_response(),
+    match state.store.load_download_rows().await {
+        Ok(downloads) => downloads
+            .into_iter()
+            .find(|download| download.download_id == download_id)
+            .map_or_else(
+                || (StatusCode::NOT_FOUND, "download not found").into_response(),
+                |download| download_row(&download).into_response(),
+            ),
         Err(error) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("failed to load download row: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn download_rows_route(State(state): State<WebState>) -> impl IntoResponse {
+    match state.store.load_download_rows().await {
+        Ok(downloads) => download_rows(&downloads).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to load download rows: {error}"),
         )
             .into_response(),
     }
@@ -145,7 +162,7 @@ fn page(title: &str, body: Markup) -> String {
     .into_string()
 }
 
-fn download_row(download: &TrackedDownload) -> Markup {
+fn download_row(download: &DownloadRow) -> Markup {
     html! {
         tr id=(format!("download-row-{}", download.download_id)) data-download-id=(&download.download_id) {
             td {
@@ -156,9 +173,17 @@ fn download_row(download: &TrackedDownload) -> Markup {
             td { span class=(lifecycle_class(&download.lifecycle_state)) { (download.lifecycle_state.as_str()) } }
             td { (&download.status) " / " (&download.tracked_download_state) }
             td class="path" { (&download.output_path) }
-            td { (download.generated_track_count()) }
+            td { (download.generated_track_count) }
             td { (&download.updated_at) }
             td { (download.completed_at.as_deref().unwrap_or("-")) }
+        }
+    }
+}
+
+fn download_rows(downloads: &[DownloadRow]) -> Markup {
+    html! {
+        @for download in downloads {
+            (download_row(download))
         }
     }
 }
@@ -343,16 +368,18 @@ fn format_size(size: Option<i64>) -> String {
 const HISTORY_SCRIPT: &str = r#"
 const rows = document.getElementById("downloads-rows");
 if (rows) {
+  const table = document.getElementById("downloads-table");
+  const empty = document.getElementById("downloads-empty");
   const refreshRows = async () => {
-    const currentRows = [...rows.querySelectorAll("tr[data-download-id]")];
-    await Promise.all(currentRows.map(async (row) => {
-      const id = row.dataset.downloadId;
-      if (!id) return;
-      const response = await fetch(`/downloads/${id}/row`, { headers: { "x-requested-with": "fetch" } });
-      if (!response.ok) return;
-      row.outerHTML = await response.text();
-    }));
+    const response = await fetch("/downloads/rows", { headers: { "x-requested-with": "fetch" } });
+    if (!response.ok) return;
+    const body = await response.text();
+    rows.innerHTML = body;
+    const hasRows = body.trim().length > 0;
+    if (table) table.hidden = !hasRows;
+    if (empty) empty.hidden = hasRows;
   };
+  refreshRows();
   setInterval(refreshRows, 10000);
 }
 "#;
@@ -559,5 +586,31 @@ mod tests {
         assert!(rendered.contains("Input Files"));
         assert!(rendered.contains("/downloads/album/album.cue"));
         assert!(rendered.contains("/downloads/album/01.flac"));
+    }
+
+    #[tokio::test]
+    async fn rows_endpoint_renders_all_rows_in_one_response() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SqliteDownloadStore::open(tmp.path()).unwrap();
+        let download = TrackedDownload::pending(
+            "abc".into(),
+            "Album".into(),
+            "completed".into(),
+            "/downloads/album".into(),
+            "importFailed".into(),
+        );
+        store.upsert_tracked_download(&download).await.unwrap();
+
+        let app = router(store);
+        let response = app
+            .oneshot(Request::builder().uri("/downloads/rows").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let rendered = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(rendered.contains("download-row-abc"));
+        assert!(rendered.contains("/downloads/abc"));
+        assert!(rendered.contains("0"));
     }
 }

--- a/src/adapters/web.rs
+++ b/src/adapters/web.rs
@@ -1,0 +1,570 @@
+use axum::{
+    Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
+    routing::get,
+};
+use maud::{DOCTYPE, Markup, PreEscaped, html};
+
+use crate::adapters::sqlite_download_store::SqliteDownloadStore;
+use crate::application::ports::DownloadStore;
+use crate::domain::{
+    CueSheet, CueSheetStatus, DownloadLifecycleState, GeneratedTrack, InputFile, InputFileKind,
+    TrackCleanupStatus, TrackedDownload,
+};
+
+#[derive(Clone)]
+struct WebState {
+    store: SqliteDownloadStore,
+}
+
+pub fn router(store: SqliteDownloadStore) -> Router {
+    Router::new()
+        .route("/", get(index))
+        .route("/healthz", get(healthz))
+        .route("/downloads/{download_id}", get(download_detail))
+        .route("/downloads/{download_id}/content", get(download_detail_content))
+        .route("/downloads/{download_id}/row", get(download_row_route))
+        .with_state(WebState { store })
+}
+
+async fn healthz() -> impl IntoResponse {
+    (StatusCode::OK, "ok")
+}
+
+async fn index(State(state): State<WebState>) -> Response {
+    match state.store.load_tracked_downloads().await {
+        Ok(downloads) => Html(page(
+            "Splittarr",
+            html! {
+                h1 { "Splittarr" }
+                section class="panel" {
+                    h2 { "Download History" }
+                    p id="downloads-empty" class="muted" hidden[!downloads.is_empty()] {
+                        "No downloads have been tracked yet."
+                    }
+                    table id="downloads-table" hidden[downloads.is_empty()] {
+                        thead {
+                            tr {
+                                th { "Download" }
+                                th { "Lifecycle" }
+                                th { "Lidarr" }
+                                th { "Output Path" }
+                                th { "Tracks" }
+                                th { "Updated" }
+                                th { "Completed" }
+                            }
+                        }
+                        tbody id="downloads-rows" {
+                            @for download in &downloads {
+                                (download_row(download))
+                            }
+                        }
+                    }
+                }
+                script { (PreEscaped(HISTORY_SCRIPT)) }
+            },
+        ))
+        .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to load downloads: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn download_row_route(
+    State(state): State<WebState>,
+    Path(download_id): Path<String>,
+) -> impl IntoResponse {
+    match state.store.get_tracked_download(&download_id).await {
+        Ok(Some(download)) => download_row(&download).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "download not found").into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to load download row: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn download_detail(State(state): State<WebState>, Path(download_id): Path<String>) -> Response {
+    match state.store.get_tracked_download(&download_id).await {
+        Ok(Some(download)) => Html(page(
+            &download.title,
+            html! {
+                nav { a href="/" { "Download History" } }
+                div id="download-detail-content" data-download-id=(&download.download_id) {
+                    (download_content(&download))
+                }
+                script { (PreEscaped(DETAIL_SCRIPT)) }
+            },
+        ))
+        .into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "download not found").into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to load download detail: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn download_detail_content(
+    State(state): State<WebState>,
+    Path(download_id): Path<String>,
+) -> impl IntoResponse {
+    match state.store.get_tracked_download(&download_id).await {
+        Ok(Some(download)) => download_content(&download).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "download not found").into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to load download detail content: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+fn page(title: &str, body: Markup) -> String {
+    html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) }
+                style { (STYLE) }
+            }
+            body {
+                main { (body) }
+            }
+        }
+    }
+    .into_string()
+}
+
+fn download_row(download: &TrackedDownload) -> Markup {
+    html! {
+        tr id=(format!("download-row-{}", download.download_id)) data-download-id=(&download.download_id) {
+            td {
+                a href=(format!("/downloads/{}", download.download_id)) {
+                    (&download.title)
+                }
+            }
+            td { span class=(lifecycle_class(&download.lifecycle_state)) { (download.lifecycle_state.as_str()) } }
+            td { (&download.status) " / " (&download.tracked_download_state) }
+            td class="path" { (&download.output_path) }
+            td { (download.generated_track_count()) }
+            td { (&download.updated_at) }
+            td { (download.completed_at.as_deref().unwrap_or("-")) }
+        }
+    }
+}
+
+fn download_content(download: &TrackedDownload) -> Markup {
+    html! {
+        h1 { (&download.title) }
+        section class="panel grid" {
+            div { strong { "Lifecycle" } span class=(lifecycle_class(&download.lifecycle_state)) { (download.lifecycle_state.as_str()) } }
+            div { strong { "Lidarr status" } span { (&download.status) } }
+            div { strong { "Tracked state" } span { (&download.tracked_download_state) } }
+            div { strong { "Generated tracks" } span { (download.generated_track_count()) } }
+            div { strong { "First seen" } span { (download.first_seen_at.as_deref().unwrap_or("-")) } }
+            div { strong { "Last seen in queue" } span { (download.last_seen_in_queue_at.as_deref().unwrap_or("-")) } }
+            div { strong { "Processing started" } span { (download.processing_started_at.as_deref().unwrap_or("-")) } }
+            div { strong { "Processing finished" } span { (download.processing_finished_at.as_deref().unwrap_or("-")) } }
+            div { strong { "Cleanup started" } span { (download.cleanup_started_at.as_deref().unwrap_or("-")) } }
+            div { strong { "Cleanup finished" } span { (download.cleanup_finished_at.as_deref().unwrap_or("-")) } }
+            div { strong { "Completed at" } span { (download.completed_at.as_deref().unwrap_or("-")) } }
+            div class="wide" { strong { "Output path" } span class="path" { (&download.output_path) } }
+        }
+        section class="panel" {
+            h2 { "Last Error" }
+            @if let Some(error) = &download.last_error {
+                pre class="error-block" { (error) }
+            } @else {
+                p class="muted" { "No error recorded." }
+            }
+        }
+        section class="panel" {
+            h2 { "Input Files" }
+            @if download.input_files.is_empty() {
+                p class="muted" { "No input files have been recorded yet." }
+            } @else {
+                table {
+                    thead {
+                        tr {
+                            th { "Kind" }
+                            th { "Path" }
+                            th { "Size" }
+                            th { "Captured" }
+                        }
+                    }
+                    tbody {
+                        @for input in &download.input_files {
+                            (input_row(input))
+                        }
+                    }
+                }
+            }
+        }
+        section class="panel" {
+            h2 { "Cue Sheets" }
+            @if download.cue_sheets.is_empty() {
+                p class="muted" { "No cue sheets have been recorded yet." }
+            } @else {
+                @for cue in &download.cue_sheets {
+                    (cue_card(cue))
+                }
+            }
+        }
+        section class="panel" {
+            h2 { "Output Files" }
+            @if download.generated_track_count() == 0 {
+                p class="muted" { "No generated tracks have been recorded yet." }
+            } @else {
+                table {
+                    thead {
+                        tr {
+                            th { "Path" }
+                            th { "Size" }
+                            th { "Cleanup" }
+                            th { "Deleted At" }
+                        }
+                    }
+                    tbody {
+                        @for cue in &download.cue_sheets {
+                            @for track in &cue.tracks {
+                                (track_row(track))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn input_row(input: &InputFile) -> Markup {
+    html! {
+        tr {
+            td { (input_kind_label(input.kind)) }
+            td class="path" { (&input.path) }
+            td { (format_size(input.size_bytes)) }
+            td { (&input.captured_at) }
+        }
+    }
+}
+
+fn cue_card(cue: &CueSheet) -> Markup {
+    html! {
+        article class="card" {
+            h3 class="path" { (&cue.path) }
+            p {
+                span class=(cue_status_class(cue.status)) { (cue.status.as_str()) }
+                " "
+                span class="muted" { (&cue.updated_at) }
+            }
+            @if let Some(message) = &cue.message {
+                pre { (message) }
+            }
+        }
+    }
+}
+
+fn track_row(track: &GeneratedTrack) -> Markup {
+    html! {
+        tr {
+            td class="path" { (&track.path) }
+            td { (format_size(track.size_bytes)) }
+            td {
+                span class=(cleanup_class(track.cleanup_status)) { (track.cleanup_status.as_str()) }
+                @if let Some(message) = &track.cleanup_message {
+                    div class="muted" { (message) }
+                }
+            }
+            td { (track.deleted_at.as_deref().unwrap_or("-")) }
+        }
+    }
+}
+
+fn input_kind_label(kind: InputFileKind) -> &'static str {
+    match kind {
+        InputFileKind::Cue => "cue",
+        InputFileKind::Audio => "audio",
+    }
+}
+
+fn lifecycle_class(state: &DownloadLifecycleState) -> &'static str {
+    match state {
+        DownloadLifecycleState::Completed => "status status-ok",
+        DownloadLifecycleState::Failed => "status status-error",
+        DownloadLifecycleState::AwaitingImport => "status status-warn",
+        DownloadLifecycleState::Detected
+        | DownloadLifecycleState::Processing
+        | DownloadLifecycleState::CleaningUp => "status status-active",
+    }
+}
+
+fn cue_status_class(state: CueSheetStatus) -> &'static str {
+    match state {
+        CueSheetStatus::Split => "status status-ok",
+        CueSheetStatus::Failed => "status status-error",
+        CueSheetStatus::Skipped => "status status-warn",
+        CueSheetStatus::Pending => "status status-active",
+    }
+}
+
+fn cleanup_class(status: TrackCleanupStatus) -> &'static str {
+    match status {
+        TrackCleanupStatus::Deleted => "status status-ok",
+        TrackCleanupStatus::Missing => "status status-warn",
+        TrackCleanupStatus::DeleteFailed => "status status-error",
+        TrackCleanupStatus::Pending => "status status-active",
+    }
+}
+
+fn format_size(size: Option<i64>) -> String {
+    let Some(size) = size else {
+        return "-".into();
+    };
+    let mut value = size as f64;
+    let units = ["B", "KB", "MB", "GB", "TB"];
+    let mut index = 0;
+    while value >= 1024.0 && index < units.len() - 1 {
+        value /= 1024.0;
+        index += 1;
+    }
+    format!("{value:.1} {}", units[index])
+}
+
+const HISTORY_SCRIPT: &str = r#"
+const rows = document.getElementById("downloads-rows");
+if (rows) {
+  const refreshRows = async () => {
+    const currentRows = [...rows.querySelectorAll("tr[data-download-id]")];
+    await Promise.all(currentRows.map(async (row) => {
+      const id = row.dataset.downloadId;
+      if (!id) return;
+      const response = await fetch(`/downloads/${id}/row`, { headers: { "x-requested-with": "fetch" } });
+      if (!response.ok) return;
+      row.outerHTML = await response.text();
+    }));
+  };
+  setInterval(refreshRows, 10000);
+}
+"#;
+
+const DETAIL_SCRIPT: &str = r#"
+const detailContent = document.getElementById("download-detail-content");
+if (detailContent) {
+  const id = detailContent.dataset.downloadId;
+  const refreshDetail = async () => {
+    if (!id) return;
+    const response = await fetch(`/downloads/${id}/content`, { headers: { "x-requested-with": "fetch" } });
+    if (!response.ok) return;
+    detailContent.innerHTML = await response.text();
+  };
+  setInterval(refreshDetail, 10000);
+}
+"#;
+
+const STYLE: &str = r#"
+:root {
+  --bg: #f5f3ee;
+  --panel: #fffdf8;
+  --text: #1f2624;
+  --muted: #66716d;
+  --border: #d8d5ca;
+  --accent: #2a6b61;
+  --ok: #1d7c56;
+  --warn: #8c6500;
+  --error: #ad3434;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: linear-gradient(180deg, #efe9dc 0%, var(--bg) 240px);
+  color: var(--text);
+  font: 15px/1.45 Georgia, "Iowan Old Style", "Palatino Linotype", serif;
+}
+main {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 28px auto 48px;
+}
+h1 { margin: 0 0 18px; font-size: 34px; }
+h2 { margin: 0 0 14px; font-size: 20px; }
+h3 { margin: 0 0 8px; font-size: 16px; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+nav { margin-bottom: 14px; }
+.panel {
+  background: color-mix(in srgb, var(--panel), white 15%);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 18px;
+  margin: 14px 0;
+  box-shadow: 0 8px 24px rgba(38, 34, 23, 0.06);
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.grid div {
+  display: grid;
+  gap: 4px;
+}
+.grid .wide {
+  grid-column: 1 / -1;
+}
+strong {
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+th, td {
+  padding: 10px 8px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+th {
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.status {
+  display: inline-block;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 12px;
+}
+.status-ok { color: var(--ok); border-color: var(--ok); }
+.status-warn { color: var(--warn); border-color: var(--warn); }
+.status-error { color: var(--error); border-color: var(--error); }
+.status-active { color: var(--accent); border-color: var(--accent); }
+.muted { color: var(--muted); }
+.path { word-break: break-all; font-family: "SFMono-Regular", Consolas, monospace; }
+.card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px;
+  margin-top: 12px;
+}
+pre {
+  overflow: auto;
+  max-height: 420px;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #f4f0e7;
+}
+.error-block { color: var(--error); }
+@media (max-width: 900px) {
+  table, thead, tbody, th, td, tr { display: block; }
+  thead { display: none; }
+  tr {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    margin-bottom: 12px;
+    padding: 8px;
+  }
+  td {
+    border: none;
+    padding: 6px 0;
+  }
+}
+"#;
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    use super::router;
+    use crate::adapters::sqlite_download_store::SqliteDownloadStore;
+    use crate::application::ports::DownloadStore;
+    use crate::domain::{CueSheetStatus, InputFileKind, RecordedTrack, TrackedDownload};
+
+    #[tokio::test]
+    async fn index_renders_empty_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = router(SqliteDownloadStore::open(tmp.path()).unwrap());
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let rendered = String::from_utf8(body.to_vec()).unwrap();
+        assert!(rendered.contains("No downloads have been tracked yet."));
+    }
+
+    #[tokio::test]
+    async fn detail_renders_recorded_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = SqliteDownloadStore::open(tmp.path()).unwrap();
+        let download = TrackedDownload::pending(
+            "abc".into(),
+            "Album".into(),
+            "completed".into(),
+            "/downloads/album".into(),
+            "importFailed".into(),
+        );
+        store.upsert_tracked_download(&download).await.unwrap();
+        store.mark_download_processing("abc").await.unwrap();
+        let cue = store
+            .get_or_create_cue_sheet("abc", std::path::Path::new("/downloads/album/album.cue"))
+            .await
+            .unwrap();
+        store
+            .record_input_file(
+                "abc",
+                Some(&cue.id),
+                std::path::Path::new("/downloads/album/album.cue"),
+                InputFileKind::Cue,
+                Some(12),
+            )
+            .await
+            .unwrap();
+        store
+            .record_cue_result(
+                &cue,
+                CueSheetStatus::Split,
+                None,
+                &[RecordedTrack {
+                    path: "/downloads/album/01.flac".into(),
+                    size_bytes: Some(64),
+                }],
+            )
+            .await
+            .unwrap();
+
+        let app = router(store);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/downloads/abc")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let rendered = String::from_utf8(body.to_vec()).unwrap();
+        assert!(rendered.contains("Input Files"));
+        assert!(rendered.contains("/downloads/album/album.cue"));
+        assert!(rendered.contains("/downloads/album/01.flac"));
+    }
+}

--- a/src/adapters/web.rs
+++ b/src/adapters/web.rs
@@ -83,14 +83,9 @@ async fn download_row_route(
     State(state): State<WebState>,
     Path(download_id): Path<String>,
 ) -> impl IntoResponse {
-    match state.store.load_download_rows().await {
-        Ok(downloads) => downloads
-            .into_iter()
-            .find(|download| download.download_id == download_id)
-            .map_or_else(
-                || (StatusCode::NOT_FOUND, "download not found").into_response(),
-                |download| download_row(&download).into_response(),
-            ),
+    match state.store.load_download_row(&download_id).await {
+        Ok(Some(download)) => download_row(&download).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "download not found").into_response(),
         Err(error) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("failed to load download row: {error}"),

--- a/src/adapters/web.rs
+++ b/src/adapters/web.rs
@@ -1,11 +1,11 @@
 use axum::{
-    Router,
     extract::{Path, State},
     http::StatusCode,
     response::{Html, IntoResponse, Response},
     routing::get,
+    Router,
 };
-use maud::{DOCTYPE, Markup, PreEscaped, html};
+use maud::{html, Markup, PreEscaped, DOCTYPE};
 
 use crate::adapters::sqlite_download_store::{DownloadRow, SqliteDownloadStore};
 use crate::application::ports::DownloadStore;
@@ -24,7 +24,10 @@ pub fn router(store: SqliteDownloadStore) -> Router {
         .route("/", get(index))
         .route("/healthz", get(healthz))
         .route("/downloads/{download_id}", get(download_detail))
-        .route("/downloads/{download_id}/content", get(download_detail_content))
+        .route(
+            "/downloads/{download_id}/content",
+            get(download_detail_content),
+        )
         .route("/downloads/{download_id}/row", get(download_row_route))
         .route("/downloads/rows", get(download_rows_route))
         .with_state(WebState { store })
@@ -107,7 +110,10 @@ async fn download_rows_route(State(state): State<WebState>) -> impl IntoResponse
     }
 }
 
-async fn download_detail(State(state): State<WebState>, Path(download_id): Path<String>) -> Response {
+async fn download_detail(
+    State(state): State<WebState>,
+    Path(download_id): Path<String>,
+) -> Response {
     match state.store.get_tracked_download(&download_id).await {
         Ok(Some(download)) => Html(page(
             &download.title,
@@ -526,7 +532,9 @@ mod tests {
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
             .await
             .unwrap();
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let rendered = String::from_utf8(body.to_vec()).unwrap();
         assert!(rendered.contains("No downloads have been tracked yet."));
     }
@@ -581,7 +589,9 @@ mod tests {
             )
             .await
             .unwrap();
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let rendered = String::from_utf8(body.to_vec()).unwrap();
         assert!(rendered.contains("Input Files"));
         assert!(rendered.contains("/downloads/album/album.cue"));
@@ -603,10 +613,17 @@ mod tests {
 
         let app = router(store);
         let response = app
-            .oneshot(Request::builder().uri("/downloads/rows").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/downloads/rows")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let rendered = String::from_utf8(body.to_vec()).unwrap();
 
         assert!(rendered.contains("download-row-abc"));

--- a/src/adapters/web.rs
+++ b/src/adapters/web.rs
@@ -373,44 +373,53 @@ if (detailContent) {
 
 const STYLE: &str = r#"
 :root {
-  --bg: #f5f3ee;
-  --panel: #fffdf8;
-  --text: #1f2624;
-  --muted: #66716d;
-  --border: #d8d5ca;
-  --accent: #2a6b61;
-  --ok: #1d7c56;
-  --warn: #8c6500;
-  --error: #ad3434;
+  color-scheme: light dark;
+  --bg: #f7f7f4;
+  --panel: #ffffff;
+  --text: #1f2428;
+  --muted: #667076;
+  --border: #d7d9d7;
+  --accent: #2f6f73;
+  --ok: #1c7c54;
+  --warn: #946200;
+  --error: #a83232;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #171918;
+    --panel: #202322;
+    --text: #edf0ee;
+    --muted: #aab2ae;
+    --border: #3a403d;
+  }
 }
 * { box-sizing: border-box; }
 body {
   margin: 0;
-  background: linear-gradient(180deg, #efe9dc 0%, var(--bg) 240px);
+  background: var(--bg);
   color: var(--text);
-  font: 15px/1.45 Georgia, "Iowan Old Style", "Palatino Linotype", serif;
+  font: 15px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 main {
-  width: min(1180px, calc(100vw - 32px));
-  margin: 28px auto 48px;
+  width: min(1160px, calc(100vw - 32px));
+  margin: 32px auto;
 }
-h1 { margin: 0 0 18px; font-size: 34px; }
-h2 { margin: 0 0 14px; font-size: 20px; }
-h3 { margin: 0 0 8px; font-size: 16px; }
+h1 { margin: 0 0 18px; font-size: 30px; }
+h2 { margin: 0 0 14px; font-size: 18px; }
+h3 { margin: 0 0 8px; font-size: 15px; }
 a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
 nav { margin-bottom: 14px; }
 .panel {
-  background: color-mix(in srgb, var(--panel), white 15%);
+  background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 8px;
   padding: 18px;
   margin: 14px 0;
-  box-shadow: 0 8px 24px rgba(38, 34, 23, 0.06);
 }
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   gap: 12px;
 }
 .grid div {
@@ -420,11 +429,10 @@ nav { margin-bottom: 14px; }
 .grid .wide {
   grid-column: 1 / -1;
 }
-strong {
+.grid strong {
   color: var(--muted);
   font-size: 12px;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 table {
   width: 100%;
@@ -440,7 +448,6 @@ th {
   color: var(--muted);
   font-size: 12px;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 .status {
   display: inline-block;
@@ -457,33 +464,19 @@ th {
 .path { word-break: break-all; font-family: "SFMono-Regular", Consolas, monospace; }
 .card {
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 14px;
   margin-top: 12px;
 }
 pre {
   overflow: auto;
-  max-height: 420px;
+  max-height: 520px;
   padding: 12px;
-  border-radius: 8px;
+  border-radius: 6px;
   border: 1px solid var(--border);
-  background: #f4f0e7;
+  background: color-mix(in srgb, var(--bg), var(--panel) 35%);
 }
 .error-block { color: var(--error); }
-@media (max-width: 900px) {
-  table, thead, tbody, th, td, tr { display: block; }
-  thead { display: none; }
-  tr {
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    margin-bottom: 12px;
-    padding: 8px;
-  }
-  td {
-    border: none;
-    padding: 6px 0;
-  }
-}
 "#;
 
 #[cfg(test)]

--- a/src/application/cleanup_processed_download.rs
+++ b/src/application/cleanup_processed_download.rs
@@ -20,9 +20,12 @@ pub async fn cleanup_processed_download<S: DownloadStore, C: TrackCleanup>(
     let mut failures = Vec::new();
     for outcome in &outcomes {
         if outcome.status == TrackCleanupStatus::DeleteFailed {
-            if let Some(message) = &outcome.message {
-                failures.push(message.clone());
-            }
+            failures.push(
+                outcome
+                    .message
+                    .clone()
+                    .unwrap_or_else(|| format!("track cleanup failed: {}", outcome.track_id)),
+            );
         }
     }
     store
@@ -43,4 +46,157 @@ pub async fn cleanup_processed_download<S: DownloadStore, C: TrackCleanup>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    use anyhow::Result;
+
+    use super::cleanup_processed_download;
+    use crate::application::ports::{DownloadStore, TrackCleanup};
+    use crate::domain::{
+        CueSheet, CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
+    };
+
+    #[derive(Default)]
+    struct FakeStore {
+        states: Mutex<Vec<String>>,
+        last_error: Mutex<Option<String>>,
+    }
+
+    impl DownloadStore for FakeStore {
+        async fn load_tracked_downloads(&self) -> Result<Vec<TrackedDownload>> {
+            Ok(Vec::new())
+        }
+
+        async fn get_tracked_download(&self, _download_id: &str) -> Result<Option<TrackedDownload>> {
+            Ok(None)
+        }
+
+        async fn upsert_tracked_download(&self, _download: &TrackedDownload) -> Result<()> {
+            Ok(())
+        }
+
+        async fn mark_download_processing(&self, _download_id: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn mark_download_awaiting_import(&self, _download_id: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn mark_download_cleanup_started(&self, _download_id: &str) -> Result<()> {
+            self.states.lock().unwrap().push("cleaning_up".into());
+            Ok(())
+        }
+
+        async fn mark_download_completed(&self, _download_id: &str) -> Result<()> {
+            self.states.lock().unwrap().push("completed".into());
+            Ok(())
+        }
+
+        async fn mark_download_failed(
+            &self,
+            _download_id: &str,
+            last_error: Option<&str>,
+        ) -> Result<()> {
+            self.states.lock().unwrap().push("failed".into());
+            *self.last_error.lock().unwrap() = last_error.map(str::to_owned);
+            Ok(())
+        }
+
+        async fn get_or_create_cue_sheet(
+            &self,
+            _download_id: &str,
+            _path: &Path,
+        ) -> Result<CueSheet> {
+            unreachable!()
+        }
+
+        async fn record_input_file(
+            &self,
+            _download_id: &str,
+            _cue_sheet_id: Option<&str>,
+            _path: &Path,
+            _kind: InputFileKind,
+            _size_bytes: Option<i64>,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn record_cue_result(
+            &self,
+            _cue_sheet: &CueSheet,
+            _status: CueSheetStatus,
+            _message: Option<&str>,
+            _tracks: &[RecordedTrack],
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn record_track_cleanup(
+            &self,
+            _download_id: &str,
+            _track_id: &str,
+            _status: TrackCleanupStatus,
+            _message: Option<&str>,
+        ) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FakeCleanup;
+
+    impl TrackCleanup for FakeCleanup {
+        async fn cleanup_download_tracks(
+            &self,
+            _download: &TrackedDownload,
+        ) -> Result<Vec<TrackCleanupOutcome>> {
+            Ok(vec![TrackCleanupOutcome {
+                track_id: "track-1".into(),
+                status: TrackCleanupStatus::DeleteFailed,
+                message: None,
+            }])
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_failed_without_message_marks_download_failed() {
+        let store = FakeStore::default();
+        let cleanup = FakeCleanup;
+        let download = TrackedDownload {
+            download_id: "download-1".into(),
+            title: "Album".into(),
+            status: "completed".into(),
+            output_path: "/downloads/album".into(),
+            tracked_download_state: "importFailed".into(),
+            lifecycle_state: DownloadLifecycleState::AwaitingImport,
+            created_at: String::new(),
+            updated_at: String::new(),
+            first_seen_at: None,
+            last_seen_in_queue_at: None,
+            processing_started_at: None,
+            processing_finished_at: None,
+            cleanup_started_at: None,
+            cleanup_finished_at: None,
+            completed_at: None,
+            input_files: Vec::new(),
+            cue_sheets: Vec::new(),
+            generated_track_count: 0,
+            last_error: None,
+        };
+
+        cleanup_processed_download(&store, &cleanup, &download)
+            .await
+            .unwrap();
+
+        assert!(store.states.lock().unwrap().contains(&"failed".to_string()));
+        assert_eq!(
+            store.last_error.lock().unwrap().as_deref(),
+            Some("track cleanup failed: track-1")
+        );
+    }
 }

--- a/src/application/cleanup_processed_download.rs
+++ b/src/application/cleanup_processed_download.rs
@@ -12,10 +12,17 @@ pub async fn cleanup_processed_download<S: DownloadStore, C: TrackCleanup>(
         .mark_download_cleanup_started(&download.download_id)
         .await
         .with_context(|| format!("mark cleanup started for {}", download.title))?;
-    let outcomes = cleanup
-        .cleanup_download_tracks(download)
-        .await
-        .with_context(|| format!("cleanup failed for {}", download.title))?;
+    let outcomes = match cleanup.cleanup_download_tracks(download).await {
+        Ok(outcomes) => outcomes,
+        Err(err) => {
+            let message = format!("cleanup failed for {}: {err}", download.title);
+            store
+                .mark_download_failed(&download.download_id, Some(&message))
+                .await
+                .context("mark download failed after cleanup error")?;
+            return Err(err).with_context(|| format!("cleanup failed for {}", download.title));
+        }
+    };
 
     let mut failures = Vec::new();
     for outcome in &outcomes {
@@ -163,6 +170,17 @@ mod tests {
         }
     }
 
+    struct FailingCleanup;
+
+    impl TrackCleanup for FailingCleanup {
+        async fn cleanup_download_tracks(
+            &self,
+            _download: &TrackedDownload,
+        ) -> Result<Vec<TrackCleanupOutcome>> {
+            anyhow::bail!("filesystem unavailable");
+        }
+    }
+
     #[tokio::test]
     async fn delete_failed_without_message_marks_download_failed() {
         let store = FakeStore::default();
@@ -197,6 +215,44 @@ mod tests {
         assert_eq!(
             store.last_error.lock().unwrap().as_deref(),
             Some("track cleanup failed: track-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_error_marks_download_failed() {
+        let store = FakeStore::default();
+        let cleanup = FailingCleanup;
+        let download = TrackedDownload {
+            download_id: "download-1".into(),
+            title: "Album".into(),
+            status: "completed".into(),
+            output_path: "/downloads/album".into(),
+            tracked_download_state: "importFailed".into(),
+            lifecycle_state: DownloadLifecycleState::AwaitingImport,
+            created_at: String::new(),
+            updated_at: String::new(),
+            first_seen_at: None,
+            last_seen_in_queue_at: None,
+            processing_started_at: None,
+            processing_finished_at: None,
+            cleanup_started_at: None,
+            cleanup_finished_at: None,
+            completed_at: None,
+            input_files: Vec::new(),
+            cue_sheets: Vec::new(),
+            generated_track_count: 0,
+            last_error: None,
+        };
+
+        let err = cleanup_processed_download(&store, &cleanup, &download)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("cleanup failed for Album"));
+        assert!(store.states.lock().unwrap().contains(&"failed".to_string()));
+        assert_eq!(
+            store.last_error.lock().unwrap().as_deref(),
+            Some("cleanup failed for Album: filesystem unavailable")
         );
     }
 }

--- a/src/application/cleanup_processed_download.rs
+++ b/src/application/cleanup_processed_download.rs
@@ -1,19 +1,51 @@
 use anyhow::{Context, Result};
 
 use crate::application::ports::{DownloadStore, TrackCleanup};
-use crate::domain::TrackedDownload;
+use crate::domain::{TrackCleanupStatus, TrackedDownload};
 
 pub async fn cleanup_processed_download<S: DownloadStore, C: TrackCleanup>(
     store: &S,
     cleanup: &C,
     download: &TrackedDownload,
 ) -> Result<()> {
-    cleanup
+    store
+        .mark_download_cleanup_started(&download.download_id)
+        .await
+        .with_context(|| format!("mark cleanup started for {}", download.title))?;
+    let outcomes = cleanup
         .cleanup_download_tracks(download)
         .await
         .with_context(|| format!("cleanup failed for {}", download.title))?;
-    store
-        .delete_download(&download.download_id)
-        .await
-        .context("delete tracked download")
+
+    let mut failures = Vec::new();
+    for outcome in outcomes {
+        if outcome.status == TrackCleanupStatus::DeleteFailed {
+            if let Some(message) = &outcome.message {
+                failures.push(message.clone());
+            }
+        }
+        store
+            .record_track_cleanup(
+                &download.download_id,
+                &outcome.track_id,
+                outcome.status,
+                outcome.message.as_deref(),
+            )
+            .await
+            .with_context(|| format!("record cleanup result for {}", download.title))?;
+    }
+
+    if failures.is_empty() {
+        store
+            .mark_download_completed(&download.download_id)
+            .await
+            .context("mark download completed")?;
+    } else {
+        store
+            .mark_download_failed(&download.download_id, Some(&failures.join("; ")))
+            .await
+            .context("mark download failed after cleanup")?;
+    }
+
+    Ok(())
 }

--- a/src/application/cleanup_processed_download.rs
+++ b/src/application/cleanup_processed_download.rs
@@ -18,22 +18,17 @@ pub async fn cleanup_processed_download<S: DownloadStore, C: TrackCleanup>(
         .with_context(|| format!("cleanup failed for {}", download.title))?;
 
     let mut failures = Vec::new();
-    for outcome in outcomes {
+    for outcome in &outcomes {
         if outcome.status == TrackCleanupStatus::DeleteFailed {
             if let Some(message) = &outcome.message {
                 failures.push(message.clone());
             }
         }
-        store
-            .record_track_cleanup(
-                &download.download_id,
-                &outcome.track_id,
-                outcome.status,
-                outcome.message.as_deref(),
-            )
-            .await
-            .with_context(|| format!("record cleanup result for {}", download.title))?;
     }
+    store
+        .record_track_cleanups(&download.download_id, &outcomes)
+        .await
+        .with_context(|| format!("record cleanup results for {}", download.title))?;
 
     if failures.is_empty() {
         store

--- a/src/application/monitor_download_queue.rs
+++ b/src/application/monitor_download_queue.rs
@@ -12,7 +12,7 @@ pub fn classify_downloads(
             if download.lifecycle_state.is_ready_for_processing() {
                 to_process.push(download);
             }
-        } else if !download.lifecycle_state.is_terminal() && download.has_generated_tracks() {
+        } else if !download.lifecycle_state.is_terminal() {
             to_cleanup.push(download);
         }
     }

--- a/src/application/monitor_download_queue.rs
+++ b/src/application/monitor_download_queue.rs
@@ -12,7 +12,7 @@ pub fn classify_downloads(
             if download.lifecycle_state.is_ready_for_processing() {
                 to_process.push(download);
             }
-        } else if !download.lifecycle_state.is_terminal() {
+        } else if !download.lifecycle_state.is_terminal() && download.has_generated_tracks() {
             to_cleanup.push(download);
         }
     }

--- a/src/application/monitor_download_queue.rs
+++ b/src/application/monitor_download_queue.rs
@@ -32,6 +32,7 @@ mod tests {
     fn classifies_downloads_by_queue_presence_and_split_state() {
         let snapshot = QueueSnapshot {
             total_records: 2,
+            pages_fetched: 1,
             active_download_ids: HashSet::from([
                 "in-queue".to_owned(),
                 "awaiting-import".to_owned(),

--- a/src/application/monitor_download_queue.rs
+++ b/src/application/monitor_download_queue.rs
@@ -9,10 +9,10 @@ pub fn classify_downloads(
 
     for download in downloads {
         if snapshot.active_download_ids.contains(&download.download_id) {
-            if !download.split_complete {
+            if download.lifecycle_state.is_ready_for_processing() {
                 to_process.push(download);
             }
-        } else {
+        } else if !download.lifecycle_state.is_terminal() && download.has_generated_tracks() {
             to_cleanup.push(download);
         }
     }
@@ -24,7 +24,7 @@ pub fn classify_downloads(
 mod tests {
     use std::collections::HashSet;
 
-    use crate::domain::{QueueSnapshot, TrackedDownload};
+    use crate::domain::{DownloadLifecycleState, QueueSnapshot, TrackedDownload};
 
     use super::classify_downloads;
 
@@ -32,12 +32,18 @@ mod tests {
     fn classifies_downloads_by_queue_presence_and_split_state() {
         let snapshot = QueueSnapshot {
             total_records: 2,
-            active_download_ids: HashSet::from(["in-queue".to_owned(), "processed".to_owned()]),
+            active_download_ids: HashSet::from([
+                "in-queue".to_owned(),
+                "awaiting-import".to_owned(),
+                "completed".to_owned(),
+            ]),
             failed_imports: Vec::new(),
         };
-        let mut processed = download("processed");
-        processed.split_complete = true;
-        let downloads = vec![download("in-queue"), processed, download("gone")];
+        let awaiting_import = with_state("awaiting-import", DownloadLifecycleState::AwaitingImport);
+        let mut completed = with_state("completed", DownloadLifecycleState::Completed);
+        completed.cue_sheets = awaiting_import.cue_sheets.clone();
+        let gone = with_state("gone", DownloadLifecycleState::AwaitingImport);
+        let downloads = vec![download("in-queue"), awaiting_import, completed, gone];
 
         let (to_process, to_cleanup) = classify_downloads(downloads, &snapshot);
 
@@ -58,12 +64,37 @@ mod tests {
     }
 
     fn download(download_id: &str) -> TrackedDownload {
-        TrackedDownload::pending(
+        let mut download = TrackedDownload::pending(
             download_id.to_owned(),
             download_id.to_owned(),
             "completed".into(),
             "/downloads/album".into(),
             "importFailed".into(),
-        )
+        );
+        download.cue_sheets = vec![crate::domain::CueSheet {
+            id: "cue-1".into(),
+            download_id: download_id.to_owned(),
+            path: "/downloads/album/album.cue".into(),
+            status: crate::domain::CueSheetStatus::Split,
+            message: None,
+            updated_at: String::new(),
+            tracks: vec![crate::domain::GeneratedTrack {
+                id: "track-1".into(),
+                cue_sheet_id: "cue-1".into(),
+                download_id: download_id.to_owned(),
+                path: "/downloads/album/01.flac".into(),
+                size_bytes: Some(1),
+                cleanup_status: crate::domain::TrackCleanupStatus::Pending,
+                cleanup_message: None,
+                deleted_at: None,
+            }],
+        }];
+        download
+    }
+
+    fn with_state(download_id: &str, state: DownloadLifecycleState) -> TrackedDownload {
+        let mut download = download(download_id);
+        download.lifecycle_state = state;
+        download
     }
 }

--- a/src/application/monitor_download_queue.rs
+++ b/src/application/monitor_download_queue.rs
@@ -31,7 +31,7 @@ mod tests {
     #[test]
     fn classifies_downloads_by_queue_presence_and_split_state() {
         let snapshot = QueueSnapshot {
-            total_records: 2,
+            total_records: 3,
             pages_fetched: 1,
             active_download_ids: HashSet::from([
                 "in-queue".to_owned(),

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -18,7 +18,6 @@ pub trait DownloadStore {
     }
     async fn get_tracked_download(&self, download_id: &str) -> Result<Option<TrackedDownload>>;
     async fn upsert_tracked_download(&self, download: &TrackedDownload) -> Result<()>;
-    async fn touch_download_queue_presence(&self, download_id: &str) -> Result<()>;
     async fn mark_download_processing(&self, download_id: &str) -> Result<()>;
     async fn mark_download_awaiting_import(&self, download_id: &str) -> Result<()>;
     async fn mark_download_cleanup_started(&self, download_id: &str) -> Result<()>;

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -13,6 +13,9 @@ pub trait QueueSource {
 
 pub trait DownloadStore {
     async fn load_tracked_downloads(&self) -> Result<Vec<TrackedDownload>>;
+    async fn load_tracked_download_summaries(&self) -> Result<Vec<TrackedDownload>> {
+        self.load_tracked_downloads().await
+    }
     async fn get_tracked_download(&self, download_id: &str) -> Result<Option<TrackedDownload>>;
     async fn upsert_tracked_download(&self, download: &TrackedDownload) -> Result<()>;
     async fn touch_download_queue_presence(&self, download_id: &str) -> Result<()>;

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -1,9 +1,10 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Result;
 
 use crate::domain::{
-    CueSheet, CueSheetStatus, DiscoveredCueSheets, QueueSnapshot, SplitOutcome, TrackedDownload,
+    CueSheet, CueSheetStatus, DiscoveredCueSheets, InputFileKind, QueueSnapshot, RecordedTrack,
+    SplitOutcome, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
 };
 
 pub trait QueueSource {
@@ -12,22 +13,37 @@ pub trait QueueSource {
 
 pub trait DownloadStore {
     async fn load_tracked_downloads(&self) -> Result<Vec<TrackedDownload>>;
+    async fn get_tracked_download(&self, download_id: &str) -> Result<Option<TrackedDownload>>;
     async fn upsert_tracked_download(&self, download: &TrackedDownload) -> Result<()>;
-    async fn mark_download_complete(
+    async fn touch_download_queue_presence(&self, download_id: &str) -> Result<()>;
+    async fn mark_download_processing(&self, download_id: &str) -> Result<()>;
+    async fn mark_download_awaiting_import(&self, download_id: &str) -> Result<()>;
+    async fn mark_download_cleanup_started(&self, download_id: &str) -> Result<()>;
+    async fn mark_download_completed(&self, download_id: &str) -> Result<()>;
+    async fn mark_download_failed(&self, download_id: &str, last_error: Option<&str>) -> Result<()>;
+    async fn get_or_create_cue_sheet(&self, download_id: &str, path: &Path) -> Result<CueSheet>;
+    async fn record_input_file(
         &self,
         download_id: &str,
-        split_complete: bool,
-        last_error: Option<&str>,
+        cue_sheet_id: Option<&str>,
+        path: &Path,
+        kind: InputFileKind,
+        size_bytes: Option<i64>,
     ) -> Result<()>;
-    async fn get_or_create_cue_sheet(&self, download_id: &str, path: &Path) -> Result<CueSheet>;
     async fn record_cue_result(
         &self,
         cue_sheet: &CueSheet,
         status: CueSheetStatus,
         message: Option<&str>,
-        tracks: &[PathBuf],
+        tracks: &[RecordedTrack],
     ) -> Result<()>;
-    async fn delete_download(&self, download_id: &str) -> Result<()>;
+    async fn record_track_cleanup(
+        &self,
+        download_id: &str,
+        track_id: &str,
+        status: TrackCleanupStatus,
+        message: Option<&str>,
+    ) -> Result<()>;
 }
 
 pub trait CueScanner {
@@ -39,5 +55,6 @@ pub trait CueSplitter {
 }
 
 pub trait TrackCleanup {
-    async fn cleanup_download_tracks(&self, download: &TrackedDownload) -> Result<()>;
+    async fn cleanup_download_tracks(&self, download: &TrackedDownload)
+    -> Result<Vec<TrackCleanupOutcome>>;
 }

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -56,6 +56,22 @@ pub trait DownloadStore {
         status: TrackCleanupStatus,
         message: Option<&str>,
     ) -> Result<()>;
+    async fn record_track_cleanups(
+        &self,
+        download_id: &str,
+        outcomes: &[TrackCleanupOutcome],
+    ) -> Result<()> {
+        for outcome in outcomes {
+            self.record_track_cleanup(
+                download_id,
+                &outcome.track_id,
+                outcome.status,
+                outcome.message.as_deref(),
+            )
+            .await?;
+        }
+        Ok(())
+    }
 }
 
 pub trait CueScanner {

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -17,6 +17,15 @@ pub trait DownloadStore {
         self.load_tracked_downloads().await
     }
     async fn get_tracked_download(&self, download_id: &str) -> Result<Option<TrackedDownload>>;
+    async fn get_tracked_downloads(&self, download_ids: &[String]) -> Result<Vec<TrackedDownload>> {
+        let mut downloads = Vec::new();
+        for download_id in download_ids {
+            if let Some(download) = self.get_tracked_download(download_id).await? {
+                downloads.push(download);
+            }
+        }
+        Ok(downloads)
+    }
     async fn upsert_tracked_download(&self, download: &TrackedDownload) -> Result<()>;
     async fn mark_download_processing(&self, download_id: &str) -> Result<()>;
     async fn mark_download_awaiting_import(&self, download_id: &str) -> Result<()>;

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -22,7 +22,8 @@ pub trait DownloadStore {
     async fn mark_download_awaiting_import(&self, download_id: &str) -> Result<()>;
     async fn mark_download_cleanup_started(&self, download_id: &str) -> Result<()>;
     async fn mark_download_completed(&self, download_id: &str) -> Result<()>;
-    async fn mark_download_failed(&self, download_id: &str, last_error: Option<&str>) -> Result<()>;
+    async fn mark_download_failed(&self, download_id: &str, last_error: Option<&str>)
+        -> Result<()>;
     async fn get_or_create_cue_sheet(&self, download_id: &str, path: &Path) -> Result<CueSheet>;
     async fn record_input_file(
         &self,
@@ -57,6 +58,8 @@ pub trait CueSplitter {
 }
 
 pub trait TrackCleanup {
-    async fn cleanup_download_tracks(&self, download: &TrackedDownload)
-    -> Result<Vec<TrackCleanupOutcome>>;
+    async fn cleanup_download_tracks(
+        &self,
+        download: &TrackedDownload,
+    ) -> Result<Vec<TrackCleanupOutcome>>;
 }

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
 use rcue::parser::parse_from_file;
+use tokio::task;
 
 use crate::application::ports::{CueScanner, CueSplitter, DownloadStore};
 use crate::domain::{
@@ -151,16 +152,50 @@ async fn snapshot_input_files<S: DownloadStore>(
     cue_sheet: &CueSheet,
     cue_path: &Path,
 ) -> Result<()> {
+    let snapshot = snapshot_input_file_details(cue_path.to_path_buf()).await?;
     store
         .record_input_file(
             download_id,
             Some(&cue_sheet.id),
             cue_path,
             InputFileKind::Cue,
-            file_size(cue_path),
+            snapshot.cue_size_bytes,
         )
         .await?;
 
+    for input in snapshot.audio_inputs {
+        store
+            .record_input_file(
+                download_id,
+                Some(&cue_sheet.id),
+                &input.path,
+                InputFileKind::Audio,
+                input.size_bytes,
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+struct SnapshotInputDetails {
+    cue_size_bytes: Option<i64>,
+    audio_inputs: Vec<SnapshotAudioInput>,
+}
+
+struct SnapshotAudioInput {
+    path: PathBuf,
+    size_bytes: Option<i64>,
+}
+
+async fn snapshot_input_file_details(cue_path: PathBuf) -> Result<SnapshotInputDetails> {
+    task::spawn_blocking(move || snapshot_input_file_details_sync(&cue_path))
+        .await
+        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+}
+
+fn snapshot_input_file_details_sync(cue_path: &Path) -> Result<SnapshotInputDetails> {
+    let cue_size_bytes = file_size(cue_path);
     let cue_path_str = cue_path.to_string_lossy();
     let cue = match parse_from_file(&cue_path_str, false) {
         Ok(cue) => cue,
@@ -169,26 +204,29 @@ async fn snapshot_input_files<S: DownloadStore>(
                 "Unable to parse cue file for input snapshot {}: {err}",
                 cue_path.display()
             );
-            return Ok(());
+            return Ok(SnapshotInputDetails {
+                cue_size_bytes,
+                audio_inputs: Vec::new(),
+            });
         }
     };
     let cue_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
+    let audio_inputs = cue
+        .files
+        .iter()
+        .map(|file| cue_dir.join(&file.file))
+        .filter_map(|path| {
+            path.exists().then(|| SnapshotAudioInput {
+                size_bytes: file_size(&path),
+                path,
+            })
+        })
+        .collect();
 
-    for input in cue.files.iter().map(|file| cue_dir.join(&file.file)) {
-        if input.exists() {
-            store
-                .record_input_file(
-                    download_id,
-                    Some(&cue_sheet.id),
-                    &input,
-                    InputFileKind::Audio,
-                    file_size(&input),
-                )
-                .await?;
-        }
-    }
-
-    Ok(())
+    Ok(SnapshotInputDetails {
+        cue_size_bytes,
+        audio_inputs,
+    })
 }
 
 fn file_size(path: &Path) -> Option<i64> {
@@ -252,6 +290,7 @@ mod tests {
         states: Mutex<Vec<String>>,
         last_error: Mutex<Option<String>>,
         recorded_cues: Mutex<Vec<String>>,
+        recorded_input_files: Mutex<Vec<(String, InputFileKind)>>,
         recorded_tracks: Mutex<Vec<String>>,
     }
 
@@ -323,10 +362,14 @@ mod tests {
             &self,
             _download_id: &str,
             _cue_sheet_id: Option<&str>,
-            _path: &Path,
-            _kind: InputFileKind,
+            path: &Path,
+            kind: InputFileKind,
             _size_bytes: Option<i64>,
         ) -> Result<()> {
+            self.recorded_input_files
+                .lock()
+                .unwrap()
+                .push((path.to_string_lossy().to_string(), kind));
             Ok(())
         }
 
@@ -531,5 +574,43 @@ mod tests {
 
         assert!(cue_references_audio_file(&target_cue, &target_audio));
         assert!(!cue_references_audio_file(&target_cue, &other_audio));
+    }
+
+    #[tokio::test]
+    async fn invalid_cue_snapshot_records_cue_file_and_continues_processing() {
+        let tmp = tempdir().unwrap();
+        let cue_path = tmp.path().join("broken.cue");
+        fs::write(&cue_path, "this is not a valid cue sheet").unwrap();
+
+        let store = FakeStore::default();
+        let scanner = FakeScanner {
+            roots: Mutex::new(Vec::new()),
+            cue_files: vec![cue_path.clone()],
+        };
+        let splitter = FakeSplitter {
+            calls: Mutex::new(Vec::new()),
+        };
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Broken".into(),
+            "completed".into(),
+            tmp.path().to_string_lossy().to_string(),
+            "importFailed".into(),
+        );
+
+        process_tracked_download(&store, &scanner, &splitter, download)
+            .await
+            .unwrap();
+
+        assert_eq!(splitter.calls.lock().unwrap().as_slice(), &[cue_path.clone()]);
+        assert_eq!(
+            store.recorded_input_files.lock().unwrap().as_slice(),
+            &[(cue_path.to_string_lossy().to_string(), InputFileKind::Cue)]
+        );
+        assert!(store
+            .states
+            .lock()
+            .unwrap()
+            .contains(&"awaiting_import".to_string()));
     }
 }

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -1,10 +1,13 @@
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use rcue::parser::parse_from_file;
 
 use crate::application::ports::{CueScanner, CueSplitter, DownloadStore};
 use crate::domain::{
-    CueSheet, CueSheetStatus, FailedImportCandidate, SplitOutcome, SplitStatus, TrackedDownload,
+    CueSheet, CueSheetStatus, FailedImportCandidate, InputFileKind, RecordedTrack, SplitOutcome,
+    SplitStatus, TrackedDownload,
 };
 
 pub async fn register_failed_imports<S: DownloadStore>(
@@ -21,6 +24,7 @@ pub async fn register_failed_imports<S: DownloadStore>(
             download.status = candidate.status.clone();
             download.output_path = candidate.output_path.clone();
             download.tracked_download_state = candidate.tracked_download_state.clone();
+            store.touch_download_queue_presence(&download.download_id).await?;
             store.upsert_tracked_download(download).await?;
             continue;
         }
@@ -50,6 +54,7 @@ where
     C: CueScanner,
     P: CueSplitter,
 {
+    store.mark_download_processing(&download.download_id).await?;
     let output_path = PathBuf::from(&download.output_path);
     let scan = scanner.find_cue_sheets(&output_path).await?;
 
@@ -59,7 +64,7 @@ where
 
     if scan.cue_files.is_empty() {
         store
-            .mark_download_complete(&download.download_id, false, Some("no cue files found"))
+            .mark_download_failed(&download.download_id, Some("no cue files found"))
             .await?;
         return Ok(());
     }
@@ -71,6 +76,7 @@ where
         let cue_sheet = store
             .get_or_create_cue_sheet(&download.download_id, &cue_path)
             .await?;
+        snapshot_input_files(store, &download.download_id, &cue_sheet, &cue_path).await?;
 
         if cue_sheet.status.is_terminal_success() {
             continue;
@@ -96,13 +102,15 @@ where
     } else {
         Some(failures.join("; "))
     };
-    store
-        .mark_download_complete(
-            &download.download_id,
-            all_cues_complete,
-            error_message.as_deref(),
-        )
-        .await?;
+    if all_cues_complete {
+        store
+            .mark_download_awaiting_import(&download.download_id)
+            .await?;
+    } else {
+        store
+            .mark_download_failed(&download.download_id, error_message.as_deref())
+            .await?;
+    }
 
     println!("Done processing {}", download.title);
     Ok(())
@@ -117,7 +125,58 @@ async fn store_split_result<S: DownloadStore>(
         SplitStatus::Split => CueSheetStatus::Split,
         SplitStatus::Skipped => CueSheetStatus::Skipped,
     };
+    let tracks = result
+        .tracks
+        .iter()
+        .map(|path| RecordedTrack {
+            path: path.to_string_lossy().to_string(),
+            size_bytes: file_size(path),
+        })
+        .collect::<Vec<_>>();
     store
-        .record_cue_result(cue_sheet, status, result.message.as_deref(), &result.tracks)
+        .record_cue_result(cue_sheet, status, result.message.as_deref(), &tracks)
         .await
+}
+
+async fn snapshot_input_files<S: DownloadStore>(
+    store: &S,
+    download_id: &str,
+    cue_sheet: &CueSheet,
+    cue_path: &Path,
+) -> Result<()> {
+    store
+        .record_input_file(
+            download_id,
+            Some(&cue_sheet.id),
+            cue_path,
+            InputFileKind::Cue,
+            file_size(cue_path),
+        )
+        .await?;
+
+    let cue_path_str = cue_path.to_string_lossy();
+    let cue = parse_from_file(&cue_path_str, false)?;
+    let cue_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
+
+    for input in cue.files.iter().map(|file| cue_dir.join(&file.file)) {
+        if input.exists() {
+            store
+                .record_input_file(
+                    download_id,
+                    Some(&cue_sheet.id),
+                    &input,
+                    InputFileKind::Audio,
+                    file_size(&input),
+                )
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn file_size(path: &Path) -> Option<i64> {
+    fs::metadata(path)
+        .ok()
+        .and_then(|metadata| i64::try_from(metadata.len()).ok())
 }

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use rcue::parser::parse_from_file;
 
 use crate::application::ports::{CueScanner, CueSplitter, DownloadStore};
@@ -53,9 +53,17 @@ where
     C: CueScanner,
     P: CueSplitter,
 {
-    store.mark_download_processing(&download.download_id).await?;
+    store
+        .mark_download_processing(&download.download_id)
+        .await?;
     let output_path = PathBuf::from(&download.output_path);
-    let scan = scanner.find_cue_sheets(&output_path).await?;
+    let scan_root = scan_root_for(&output_path)?;
+    let mut scan = scanner.find_cue_sheets(&scan_root).await?;
+
+    if output_path.is_file() {
+        scan.cue_files
+            .retain(|cue_path| cue_references_audio_file(cue_path, &output_path));
+    }
 
     for error in &scan.errors {
         eprintln!("Scan warning for {}: {error}", download.title);
@@ -187,4 +195,341 @@ fn file_size(path: &Path) -> Option<i64> {
     fs::metadata(path)
         .ok()
         .and_then(|metadata| i64::try_from(metadata.len()).ok())
+}
+
+fn scan_root_for(output_path: &Path) -> Result<PathBuf> {
+    if output_path.is_dir() {
+        return Ok(output_path.to_path_buf());
+    }
+    if output_path.is_file() {
+        return output_path.parent().map(Path::to_path_buf).ok_or_else(|| {
+            anyhow!(
+                "download output file has no parent directory: {}",
+                output_path.display()
+            )
+        });
+    }
+    Ok(output_path.to_path_buf())
+}
+
+fn cue_references_audio_file(cue_path: &Path, audio_path: &Path) -> bool {
+    let cue = match parse_from_file(&cue_path.to_string_lossy(), false) {
+        Ok(cue) => cue,
+        Err(err) => {
+            eprintln!(
+                "Unable to parse cue file while matching audio {}: {err}",
+                cue_path.display()
+            );
+            return false;
+        }
+    };
+    let cue_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
+
+    cue.files
+        .iter()
+        .map(|file| cue_dir.join(&file.file))
+        .any(|candidate| candidate == audio_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+
+    use anyhow::Result;
+    use tempfile::tempdir;
+
+    use super::{cue_references_audio_file, process_tracked_download};
+    use crate::application::ports::{CueScanner, CueSplitter, DownloadStore};
+    use crate::domain::{
+        CueSheet, CueSheetStatus, DiscoveredCueSheets, InputFileKind, RecordedTrack, SplitOutcome,
+        SplitStatus, TrackCleanupStatus, TrackedDownload,
+    };
+
+    #[derive(Default)]
+    struct FakeStore {
+        states: Mutex<Vec<String>>,
+        last_error: Mutex<Option<String>>,
+        recorded_cues: Mutex<Vec<String>>,
+        recorded_tracks: Mutex<Vec<String>>,
+    }
+
+    impl DownloadStore for FakeStore {
+        async fn load_tracked_downloads(&self) -> Result<Vec<TrackedDownload>> {
+            Ok(Vec::new())
+        }
+
+        async fn get_tracked_download(
+            &self,
+            _download_id: &str,
+        ) -> Result<Option<TrackedDownload>> {
+            Ok(None)
+        }
+
+        async fn upsert_tracked_download(&self, _download: &TrackedDownload) -> Result<()> {
+            Ok(())
+        }
+
+        async fn mark_download_processing(&self, _download_id: &str) -> Result<()> {
+            self.states.lock().unwrap().push("processing".into());
+            Ok(())
+        }
+
+        async fn mark_download_awaiting_import(&self, _download_id: &str) -> Result<()> {
+            self.states.lock().unwrap().push("awaiting_import".into());
+            Ok(())
+        }
+
+        async fn mark_download_cleanup_started(&self, _download_id: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn mark_download_completed(&self, _download_id: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn mark_download_failed(
+            &self,
+            _download_id: &str,
+            last_error: Option<&str>,
+        ) -> Result<()> {
+            self.states.lock().unwrap().push("failed".into());
+            *self.last_error.lock().unwrap() = last_error.map(str::to_owned);
+            Ok(())
+        }
+
+        async fn get_or_create_cue_sheet(
+            &self,
+            download_id: &str,
+            path: &Path,
+        ) -> Result<CueSheet> {
+            self.recorded_cues
+                .lock()
+                .unwrap()
+                .push(path.to_string_lossy().to_string());
+            Ok(CueSheet {
+                id: format!("cue:{}", path.display()),
+                download_id: download_id.to_owned(),
+                path: path.to_string_lossy().to_string(),
+                status: CueSheetStatus::Pending,
+                message: None,
+                updated_at: "now".into(),
+                tracks: Vec::new(),
+            })
+        }
+
+        async fn record_input_file(
+            &self,
+            _download_id: &str,
+            _cue_sheet_id: Option<&str>,
+            _path: &Path,
+            _kind: InputFileKind,
+            _size_bytes: Option<i64>,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn record_cue_result(
+            &self,
+            _cue_sheet: &CueSheet,
+            status: CueSheetStatus,
+            message: Option<&str>,
+            tracks: &[RecordedTrack],
+        ) -> Result<()> {
+            if status == CueSheetStatus::Split {
+                self.recorded_tracks
+                    .lock()
+                    .unwrap()
+                    .extend(tracks.iter().map(|track| track.path.clone()));
+            }
+            if status == CueSheetStatus::Failed {
+                *self.last_error.lock().unwrap() = message.map(str::to_owned);
+            }
+            Ok(())
+        }
+
+        async fn record_track_cleanup(
+            &self,
+            _download_id: &str,
+            _track_id: &str,
+            _status: TrackCleanupStatus,
+            _message: Option<&str>,
+        ) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FakeScanner {
+        roots: Mutex<Vec<PathBuf>>,
+        cue_files: Vec<PathBuf>,
+    }
+
+    impl CueScanner for FakeScanner {
+        async fn find_cue_sheets(&self, root: &Path) -> Result<DiscoveredCueSheets> {
+            self.roots.lock().unwrap().push(root.to_path_buf());
+            Ok(DiscoveredCueSheets {
+                cue_files: self.cue_files.clone(),
+                errors: Vec::new(),
+            })
+        }
+    }
+
+    struct FakeSplitter {
+        calls: Mutex<Vec<PathBuf>>,
+    }
+
+    impl CueSplitter for FakeSplitter {
+        async fn split_cue(&self, cue_path: &Path) -> Result<SplitOutcome> {
+            self.calls.lock().unwrap().push(cue_path.to_path_buf());
+            Ok(SplitOutcome {
+                status: SplitStatus::Split,
+                tracks: vec![cue_path.with_file_name("01 - Track.flac")],
+                message: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn processes_file_output_path_using_parent_directory_and_matching_cue() {
+        let tmp = tempdir().unwrap();
+        let audio_path = tmp.path().join("single.flac");
+        let cue_path = tmp.path().join("single.cue");
+        fs::write(&audio_path, b"audio").unwrap();
+        fs::write(
+            &cue_path,
+            "FILE \"single.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"Track\"\n    INDEX 01 00:00:00\n",
+        )
+        .unwrap();
+
+        let store = FakeStore::default();
+        let scanner = FakeScanner {
+            roots: Mutex::new(Vec::new()),
+            cue_files: vec![cue_path.clone()],
+        };
+        let splitter = FakeSplitter {
+            calls: Mutex::new(Vec::new()),
+        };
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Single".into(),
+            "completed".into(),
+            audio_path.to_string_lossy().to_string(),
+            "importFailed".into(),
+        );
+
+        process_tracked_download(&store, &scanner, &splitter, download)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            scanner.roots.lock().unwrap().as_slice(),
+            &[tmp.path().to_path_buf()]
+        );
+        assert_eq!(splitter.calls.lock().unwrap().as_slice(), &[cue_path]);
+        assert!(store
+            .states
+            .lock()
+            .unwrap()
+            .contains(&"awaiting_import".to_string()));
+    }
+
+    #[tokio::test]
+    async fn file_output_path_without_matching_cue_fails_with_no_cue_files_found() {
+        let tmp = tempdir().unwrap();
+        let audio_path = tmp.path().join("single.flac");
+        let cue_path = tmp.path().join("other.cue");
+        fs::write(&audio_path, b"audio").unwrap();
+        fs::write(
+            &cue_path,
+            "FILE \"other.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"Track\"\n    INDEX 01 00:00:00\n",
+        )
+        .unwrap();
+
+        let store = FakeStore::default();
+        let scanner = FakeScanner {
+            roots: Mutex::new(Vec::new()),
+            cue_files: vec![cue_path],
+        };
+        let splitter = FakeSplitter {
+            calls: Mutex::new(Vec::new()),
+        };
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Single".into(),
+            "completed".into(),
+            audio_path.to_string_lossy().to_string(),
+            "importFailed".into(),
+        );
+
+        process_tracked_download(&store, &scanner, &splitter, download)
+            .await
+            .unwrap();
+
+        assert_eq!(splitter.calls.lock().unwrap().len(), 0);
+        assert_eq!(
+            store.last_error.lock().unwrap().as_deref(),
+            Some("no cue files found")
+        );
+    }
+
+    #[tokio::test]
+    async fn file_output_path_ignores_unrelated_cues_in_same_directory() {
+        let tmp = tempdir().unwrap();
+        let target_audio = tmp.path().join("target.flac");
+        let other_audio = tmp.path().join("other.flac");
+        let target_cue = tmp.path().join("target.cue");
+        let other_cue = tmp.path().join("other.cue");
+        fs::write(&target_audio, b"audio").unwrap();
+        fs::write(&other_audio, b"audio").unwrap();
+        fs::write(
+            &target_cue,
+            "FILE \"target.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"Track\"\n    INDEX 01 00:00:00\n",
+        )
+        .unwrap();
+        fs::write(
+            &other_cue,
+            "FILE \"other.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"Track\"\n    INDEX 01 00:00:00\n",
+        )
+        .unwrap();
+
+        let store = FakeStore::default();
+        let scanner = FakeScanner {
+            roots: Mutex::new(Vec::new()),
+            cue_files: vec![other_cue, target_cue.clone()],
+        };
+        let splitter = FakeSplitter {
+            calls: Mutex::new(Vec::new()),
+        };
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Single".into(),
+            "completed".into(),
+            target_audio.to_string_lossy().to_string(),
+            "importFailed".into(),
+        );
+
+        process_tracked_download(&store, &scanner, &splitter, download)
+            .await
+            .unwrap();
+
+        assert_eq!(splitter.calls.lock().unwrap().as_slice(), &[target_cue]);
+    }
+
+    #[test]
+    fn cue_matching_checks_exact_referenced_audio_file() {
+        let tmp = tempdir().unwrap();
+        let target_audio = tmp.path().join("target.flac");
+        let target_cue = tmp.path().join("target.cue");
+        let other_audio = tmp.path().join("other.flac");
+        fs::write(&target_audio, b"audio").unwrap();
+        fs::write(
+            &target_cue,
+            "FILE \"target.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"Track\"\n    INDEX 01 00:00:00\n",
+        )
+        .unwrap();
+
+        assert!(cue_references_audio_file(&target_cue, &target_audio));
+        assert!(!cue_references_audio_file(&target_cue, &other_audio));
+    }
 }

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -154,7 +154,16 @@ async fn snapshot_input_files<S: DownloadStore>(
         .await?;
 
     let cue_path_str = cue_path.to_string_lossy();
-    let cue = parse_from_file(&cue_path_str, false)?;
+    let cue = match parse_from_file(&cue_path_str, false) {
+        Ok(cue) => cue,
+        Err(err) => {
+            eprintln!(
+                "Unable to parse cue file for input snapshot {}: {err}",
+                cue_path.display()
+            );
+            return Ok(());
+        }
+    };
     let cue_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
 
     for input in cue.files.iter().map(|file| cue_dir.join(&file.file)) {

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -62,8 +62,7 @@ where
     let mut scan = scanner.find_cue_sheets(&scan_root).await?;
 
     if output_path.is_file() {
-        scan.cue_files
-            .retain(|cue_path| cue_references_audio_file(cue_path, &output_path));
+        scan.cue_files = filter_cue_files_for_audio(scan.cue_files, output_path.clone()).await?;
     }
 
     for error in &scan.errors {
@@ -267,6 +266,20 @@ fn cue_references_audio_file(cue_path: &Path, audio_path: &Path) -> bool {
         .iter()
         .map(|file| cue_dir.join(&file.file))
         .any(|candidate| candidate == audio_path)
+}
+
+async fn filter_cue_files_for_audio(
+    cue_files: Vec<PathBuf>,
+    audio_path: PathBuf,
+) -> Result<Vec<PathBuf>> {
+    task::spawn_blocking(move || {
+        Ok(cue_files
+            .into_iter()
+            .filter(|cue_path| cue_references_audio_file(cue_path, &audio_path))
+            .collect())
+    })
+    .await
+    .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
 }
 
 #[cfg(test)]

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -24,7 +24,6 @@ pub async fn register_failed_imports<S: DownloadStore>(
             download.status = candidate.status.clone();
             download.output_path = candidate.output_path.clone();
             download.tracked_download_state = candidate.tracked_download_state.clone();
-            store.touch_download_queue_presence(&download.download_id).await?;
             store.upsert_tracked_download(download).await?;
             continue;
         }

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -81,7 +81,10 @@ where
             "Found {} records in Lidarr's download queue",
             snapshot.total_records
         );
-        println!("Fetched {} queue page(s) from Lidarr", snapshot.pages_fetched);
+        println!(
+            "Fetched {} queue page(s) from Lidarr",
+            snapshot.pages_fetched
+        );
 
         register_failed_imports(
             &self.download_store,
@@ -275,13 +278,24 @@ FILE "album.flac" WAVE
         );
 
         service.run_once().await.unwrap();
-        let after_split = store.get_tracked_download("download-1").await.unwrap().unwrap();
-        assert_eq!(after_split.lifecycle_state, DownloadLifecycleState::AwaitingImport);
+        let after_split = store
+            .get_tracked_download("download-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            after_split.lifecycle_state,
+            DownloadLifecycleState::AwaitingImport
+        );
         assert_eq!(after_split.generated_track_count(), 1);
         assert_eq!(after_split.input_files.len(), 2);
 
         service.run_once().await.unwrap();
-        let completed = store.get_tracked_download("download-1").await.unwrap().unwrap();
+        let completed = store
+            .get_tracked_download("download-1")
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(completed.lifecycle_state, DownloadLifecycleState::Completed);
         assert_eq!(
             completed.cue_sheets[0].tracks[0].cleanup_status,

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -94,16 +94,14 @@ where
         .await?;
 
         let (to_process, to_cleanup_candidates) = classify_downloads(downloads, &snapshot);
-        let mut to_cleanup = Vec::new();
-        for download in to_cleanup_candidates {
-            if let Some(full_download) = self
-                .download_store
-                .get_tracked_download(&download.download_id)
-                .await?
-            {
-                to_cleanup.push(full_download);
-            }
-        }
+        let to_cleanup_ids = to_cleanup_candidates
+            .into_iter()
+            .map(|download| download.download_id)
+            .collect::<Vec<_>>();
+        let to_cleanup = self
+            .download_store
+            .get_tracked_downloads(&to_cleanup_ids)
+            .await?;
 
         println!("{} downloads to be processed", to_process.len());
 

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -78,6 +78,7 @@ where
             "Found {} records in Lidarr's download queue",
             snapshot.total_records
         );
+        println!("Fetched {} queue page(s) from Lidarr", snapshot.pages_fetched);
 
         register_failed_imports(
             &self.download_store,
@@ -227,6 +228,7 @@ FILE "album.flac" WAVE
 
         let snapshot_active = QueueSnapshot {
             total_records: 1,
+            pages_fetched: 1,
             active_download_ids: HashSet::from(["download-1".to_owned()]),
             failed_imports: vec![FailedImportCandidate {
                 download_id: "download-1".into(),
@@ -238,6 +240,7 @@ FILE "album.flac" WAVE
         };
         let snapshot_gone = QueueSnapshot {
             total_records: 0,
+            pages_fetched: 1,
             active_download_ids: HashSet::new(),
             failed_imports: Vec::new(),
         };

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -153,8 +153,7 @@ mod tests {
         CueScanner, CueSplitter, DownloadStore, QueueSource, TrackCleanup,
     };
     use crate::domain::{
-        DiscoveredCueSheets, DownloadLifecycleState, FailedImportCandidate, QueueSnapshot,
-        RecordedTrack, SplitOutcome, SplitStatus, TrackCleanupOutcome, TrackCleanupStatus,
+        DiscoveredCueSheets, DownloadLifecycleState, FailedImportCandidate, QueueSnapshot, SplitOutcome, SplitStatus, TrackCleanupOutcome, TrackCleanupStatus,
     };
 
     struct FakeQueue {

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -70,7 +70,10 @@ where
     }
 
     pub async fn run_once(&self) -> Result<()> {
-        let mut downloads = self.download_store.load_tracked_downloads().await?;
+        let mut downloads = self
+            .download_store
+            .load_tracked_download_summaries()
+            .await?;
         println!("{} downloads registered in Splittarr", downloads.len());
 
         let snapshot = self.queue_source.queue_snapshot().await?;
@@ -87,7 +90,19 @@ where
         )
         .await?;
 
-        let (to_process, to_cleanup) = classify_downloads(downloads, &snapshot);
+        let (to_process, to_cleanup_candidates) = classify_downloads(downloads, &snapshot);
+        let mut to_cleanup = Vec::new();
+        for download in to_cleanup_candidates {
+            if let Some(full_download) = self
+                .download_store
+                .get_tracked_download(&download.download_id)
+                .await?
+            {
+                if full_download.has_generated_tracks() {
+                    to_cleanup.push(full_download);
+                }
+            }
+        }
 
         println!("{} downloads to be processed", to_process.len());
 

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -98,9 +98,7 @@ where
                 .get_tracked_download(&download.download_id)
                 .await?
             {
-                if full_download.has_generated_tracks() {
-                    to_cleanup.push(full_download);
-                }
+                to_cleanup.push(full_download);
             }
         }
 

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -102,7 +102,7 @@ where
                 eprintln!("Failed processing {}: {err:#}", download.title);
                 let message = err.to_string();
                 self.download_store
-                    .mark_download_complete(&download.download_id, false, Some(&message))
+                    .mark_download_failed(&download.download_id, Some(&message))
                     .await?;
             }
         }
@@ -118,5 +118,159 @@ where
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+
+    use tempfile::tempdir;
+
+    use super::MonitorService;
+    use crate::adapters::sqlite_download_store::SqliteDownloadStore;
+    use crate::application::ports::{
+        CueScanner, CueSplitter, DownloadStore, QueueSource, TrackCleanup,
+    };
+    use crate::domain::{
+        DiscoveredCueSheets, DownloadLifecycleState, FailedImportCandidate, QueueSnapshot,
+        RecordedTrack, SplitOutcome, SplitStatus, TrackCleanupOutcome, TrackCleanupStatus,
+    };
+
+    struct FakeQueue {
+        snapshots: Mutex<Vec<QueueSnapshot>>,
+    }
+
+    impl QueueSource for FakeQueue {
+        async fn queue_snapshot(&self) -> anyhow::Result<QueueSnapshot> {
+            let mut snapshots = self.snapshots.lock().unwrap();
+            Ok(if snapshots.len() > 1 {
+                snapshots.remove(0)
+            } else {
+                snapshots[0].clone()
+            })
+        }
+    }
+
+    struct FakeScanner {
+        cue_path: PathBuf,
+    }
+
+    impl CueScanner for FakeScanner {
+        async fn find_cue_sheets(&self, _root: &Path) -> anyhow::Result<DiscoveredCueSheets> {
+            Ok(DiscoveredCueSheets {
+                cue_files: vec![self.cue_path.clone()],
+                errors: Vec::new(),
+            })
+        }
+    }
+
+    struct FakeSplitter {
+        output_track: PathBuf,
+    }
+
+    impl CueSplitter for FakeSplitter {
+        async fn split_cue(&self, _cue_path: &Path) -> anyhow::Result<SplitOutcome> {
+            fs::write(&self.output_track, b"track").unwrap();
+            Ok(SplitOutcome {
+                status: SplitStatus::Split,
+                tracks: vec![self.output_track.clone()],
+                message: None,
+            })
+        }
+    }
+
+    struct FakeCleanup;
+
+    impl TrackCleanup for FakeCleanup {
+        async fn cleanup_download_tracks(
+            &self,
+            download: &crate::domain::TrackedDownload,
+        ) -> anyhow::Result<Vec<TrackCleanupOutcome>> {
+            Ok(download
+                .cue_sheets
+                .iter()
+                .flat_map(|cue| cue.tracks.iter())
+                .map(|track| TrackCleanupOutcome {
+                    track_id: track.id.clone(),
+                    status: TrackCleanupStatus::Deleted,
+                    message: None,
+                })
+                .collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn run_once_processes_then_completes_without_deleting_history() {
+        let tmp = tempdir().unwrap();
+        let album_dir = tmp.path().join("album");
+        fs::create_dir_all(&album_dir).unwrap();
+        let cue_path = album_dir.join("album.cue");
+        let audio_path = album_dir.join("album.flac");
+        let split_track = album_dir.join("01 - Track.flac");
+        fs::write(
+            &cue_path,
+            r#"PERFORMER "Artist"
+TITLE "Album"
+FILE "album.flac" WAVE
+  TRACK 01 AUDIO
+    TITLE "Track One"
+    PERFORMER "Artist"
+    INDEX 01 00:00:00
+"#,
+        )
+        .unwrap();
+        fs::write(&audio_path, b"audio").unwrap();
+
+        let snapshot_active = QueueSnapshot {
+            total_records: 1,
+            active_download_ids: HashSet::from(["download-1".to_owned()]),
+            failed_imports: vec![FailedImportCandidate {
+                download_id: "download-1".into(),
+                title: "Album".into(),
+                status: "completed".into(),
+                output_path: album_dir.to_string_lossy().to_string(),
+                tracked_download_state: "importFailed".into(),
+            }],
+        };
+        let snapshot_gone = QueueSnapshot {
+            total_records: 0,
+            active_download_ids: HashSet::new(),
+            failed_imports: Vec::new(),
+        };
+        let queue = FakeQueue {
+            snapshots: Mutex::new(vec![snapshot_active, snapshot_gone]),
+        };
+        let store = SqliteDownloadStore::open(tmp.path()).unwrap();
+        let service = MonitorService::new(
+            queue,
+            store.clone(),
+            FakeScanner {
+                cue_path: cue_path.clone(),
+            },
+            FakeSplitter {
+                output_track: split_track.clone(),
+            },
+            FakeCleanup,
+            60,
+        );
+
+        service.run_once().await.unwrap();
+        let after_split = store.get_tracked_download("download-1").await.unwrap().unwrap();
+        assert_eq!(after_split.lifecycle_state, DownloadLifecycleState::AwaitingImport);
+        assert_eq!(after_split.generated_track_count(), 1);
+        assert_eq!(after_split.input_files.len(), 2);
+
+        service.run_once().await.unwrap();
+        let completed = store.get_tracked_download("download-1").await.unwrap().unwrap();
+        assert_eq!(completed.lifecycle_state, DownloadLifecycleState::Completed);
+        assert_eq!(
+            completed.cue_sheets[0].tracks[0].cleanup_status,
+            TrackCleanupStatus::Deleted
+        );
+        assert!(completed.completed_at.is_some());
     }
 }

--- a/src/bootstrap/settings.rs
+++ b/src/bootstrap/settings.rs
@@ -22,6 +22,8 @@ pub struct CueSettings {
 pub struct LidarrSettings {
     pub url: String,
     pub api_key: String,
+    pub queue_page_size: usize,
+    pub queue_max_pages: usize,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -75,6 +77,8 @@ impl Settings {
             .set_default("check_frequency_seconds", 60)?
             .set_default("server.bind_address", "0.0.0.0:9899")?
             .set_default("cue.strict", false)?
+            .set_default("lidarr.queue_page_size", 100)?
+            .set_default("lidarr.queue_max_pages", 100)?
             .set_default("shnsplit.path", "shnsplit")?
             .set_default("shnsplit.overwrite", true)?
             .set_default("shnsplit.format", "%p - %a - %n - %t")?
@@ -128,6 +132,8 @@ data_dir = "/tmp/splittarr-data"
 [lidarr]
 url = "http://lidarr"
 api_key = "secret"
+queue_page_size = 25
+queue_max_pages = 20
 
 [server]
 bind_address = "127.0.0.1:9899"
@@ -151,6 +157,8 @@ format = "%n - %t"
         assert_eq!(settings.server.bind_address, "127.0.0.1:9899");
         assert!(settings.cue.strict);
         assert_eq!(settings.lidarr.url, "http://lidarr");
+        assert_eq!(settings.lidarr.queue_page_size, 25);
+        assert_eq!(settings.lidarr.queue_max_pages, 20);
         assert_eq!(settings.shnsplit.path, PathBuf::from("/usr/bin/shnsplit"));
         assert!(!settings.shnsplit.overwrite);
     }

--- a/src/bootstrap/settings.rs
+++ b/src/bootstrap/settings.rs
@@ -75,7 +75,7 @@ impl Settings {
         let mut builder = Config::builder()
             .set_default("data_dir", default_data_dir.to_string_lossy().to_string())?
             .set_default("check_frequency_seconds", 60)?
-            .set_default("server.bind_address", "0.0.0.0:9899")?
+            .set_default("server.bind_address", "127.0.0.1:9899")?
             .set_default("cue.strict", false)?
             .set_default("lidarr.queue_page_size", 100)?
             .set_default("lidarr.queue_max_pages", 100)?

--- a/src/bootstrap/settings.rs
+++ b/src/bootstrap/settings.rs
@@ -32,9 +32,15 @@ pub struct ShnsplitSettings {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ServerSettings {
+    pub bind_address: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct Settings {
     pub data_dir: PathBuf,
     pub check_frequency_seconds: u64,
+    pub server: ServerSettings,
     pub cue: CueSettings,
     pub lidarr: LidarrSettings,
     pub shnsplit: ShnsplitSettings,
@@ -67,6 +73,7 @@ impl Settings {
         let mut builder = Config::builder()
             .set_default("data_dir", default_data_dir.to_string_lossy().to_string())?
             .set_default("check_frequency_seconds", 60)?
+            .set_default("server.bind_address", "0.0.0.0:9899")?
             .set_default("cue.strict", false)?
             .set_default("shnsplit.path", "shnsplit")?
             .set_default("shnsplit.overwrite", true)?
@@ -122,6 +129,9 @@ data_dir = "/tmp/splittarr-data"
 url = "http://lidarr"
 api_key = "secret"
 
+[server]
+bind_address = "127.0.0.1:9899"
+
 [cue]
 strict = true
 
@@ -138,6 +148,7 @@ format = "%n - %t"
 
         assert_eq!(settings.check_frequency_seconds, 5);
         assert_eq!(settings.data_dir, PathBuf::from("/tmp/splittarr-data"));
+        assert_eq!(settings.server.bind_address, "127.0.0.1:9899");
         assert!(settings.cue.strict);
         assert_eq!(settings.lidarr.url, "http://lidarr");
         assert_eq!(settings.shnsplit.path, PathBuf::from("/usr/bin/shnsplit"));
@@ -164,20 +175,24 @@ api_key = "file-secret"
 
         std::env::set_var("SPLITTARR_CHECK_FREQUENCY_SECONDS", "9");
         std::env::set_var("SPLITTARR_LIDARR__URL", "http://from-env");
+        std::env::set_var("SPLITTARR_SERVER__BIND_ADDRESS", "0.0.0.0:1234");
 
         let settings =
             Settings::load_with_paths(Some(config_path), tmp.path().join("default"), None).unwrap();
 
         std::env::remove_var("SPLITTARR_CHECK_FREQUENCY_SECONDS");
         std::env::remove_var("SPLITTARR_LIDARR__URL");
+        std::env::remove_var("SPLITTARR_SERVER__BIND_ADDRESS");
 
         assert_eq!(settings.check_frequency_seconds, 9);
         assert_eq!(settings.lidarr.url, "http://from-env");
         assert_eq!(settings.lidarr.api_key, "file-secret");
+        assert_eq!(settings.server.bind_address, "0.0.0.0:1234");
     }
 
     fn clear_test_env() {
         std::env::remove_var("SPLITTARR_CHECK_FREQUENCY_SECONDS");
         std::env::remove_var("SPLITTARR_LIDARR__URL");
+        std::env::remove_var("SPLITTARR_SERVER__BIND_ADDRESS");
     }
 }

--- a/src/domain/cue.rs
+++ b/src/domain/cue.rs
@@ -9,6 +9,7 @@ pub struct CueSheet {
     pub path: String,
     pub status: CueSheetStatus,
     pub message: Option<String>,
+    pub updated_at: String,
     pub tracks: Vec<GeneratedTrack>,
 }
 
@@ -47,5 +48,38 @@ impl CueSheetStatus {
 
     pub fn is_terminal_success(self) -> bool {
         matches!(self, Self::Split | Self::Skipped)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InputFile {
+    pub id: String,
+    pub download_id: String,
+    pub cue_sheet_id: Option<String>,
+    pub path: String,
+    pub kind: InputFileKind,
+    pub size_bytes: Option<i64>,
+    pub captured_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputFileKind {
+    Cue,
+    Audio,
+}
+
+impl InputFileKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cue => "cue",
+            Self::Audio => "audio",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Self {
+        match value {
+            "audio" => Self::Audio,
+            _ => Self::Cue,
+        }
     }
 }

--- a/src/domain/download.rs
+++ b/src/domain/download.rs
@@ -1,4 +1,4 @@
-use crate::domain::CueSheet;
+use crate::domain::{CueSheet, InputFile};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TrackedDownload {
@@ -7,8 +7,18 @@ pub struct TrackedDownload {
     pub status: String,
     pub output_path: String,
     pub tracked_download_state: String,
+    pub lifecycle_state: DownloadLifecycleState,
+    pub created_at: String,
+    pub updated_at: String,
+    pub first_seen_at: Option<String>,
+    pub last_seen_in_queue_at: Option<String>,
+    pub processing_started_at: Option<String>,
+    pub processing_finished_at: Option<String>,
+    pub cleanup_started_at: Option<String>,
+    pub cleanup_finished_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub input_files: Vec<InputFile>,
     pub cue_sheets: Vec<CueSheet>,
-    pub split_complete: bool,
     pub last_error: Option<String>,
 }
 
@@ -26,9 +36,69 @@ impl TrackedDownload {
             status,
             output_path,
             tracked_download_state,
+            lifecycle_state: DownloadLifecycleState::Detected,
+            created_at: String::new(),
+            updated_at: String::new(),
+            first_seen_at: None,
+            last_seen_in_queue_at: None,
+            processing_started_at: None,
+            processing_finished_at: None,
+            cleanup_started_at: None,
+            cleanup_finished_at: None,
+            completed_at: None,
+            input_files: Vec::new(),
             cue_sheets: Vec::new(),
-            split_complete: false,
             last_error: None,
         }
+    }
+
+    pub fn generated_track_count(&self) -> usize {
+        self.cue_sheets.iter().map(|cue| cue.tracks.len()).sum()
+    }
+
+    pub fn has_generated_tracks(&self) -> bool {
+        self.generated_track_count() > 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DownloadLifecycleState {
+    Detected,
+    Processing,
+    AwaitingImport,
+    CleaningUp,
+    Completed,
+    Failed,
+}
+
+impl DownloadLifecycleState {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Detected => "detected",
+            Self::Processing => "processing",
+            Self::AwaitingImport => "awaiting_import",
+            Self::CleaningUp => "cleaning_up",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Self {
+        match value {
+            "processing" => Self::Processing,
+            "awaiting_import" => Self::AwaitingImport,
+            "cleaning_up" => Self::CleaningUp,
+            "completed" => Self::Completed,
+            "failed" => Self::Failed,
+            _ => Self::Detected,
+        }
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed)
+    }
+
+    pub fn is_ready_for_processing(&self) -> bool {
+        matches!(self, Self::Detected | Self::Failed | Self::Processing)
     }
 }

--- a/src/domain/download.rs
+++ b/src/domain/download.rs
@@ -19,6 +19,7 @@ pub struct TrackedDownload {
     pub completed_at: Option<String>,
     pub input_files: Vec<InputFile>,
     pub cue_sheets: Vec<CueSheet>,
+    pub generated_track_count: usize,
     pub last_error: Option<String>,
 }
 
@@ -48,12 +49,17 @@ impl TrackedDownload {
             completed_at: None,
             input_files: Vec::new(),
             cue_sheets: Vec::new(),
+            generated_track_count: 0,
             last_error: None,
         }
     }
 
     pub fn generated_track_count(&self) -> usize {
-        self.cue_sheets.iter().map(|cue| cue.tracks.len()).sum()
+        if self.generated_track_count == 0 {
+            self.cue_sheets.iter().map(|cue| cue.tracks.len()).sum()
+        } else {
+            self.generated_track_count
+        }
     }
 
     pub fn has_generated_tracks(&self) -> bool {

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -3,7 +3,7 @@ pub mod download;
 pub mod processing;
 pub mod track;
 
-pub use cue::{CueSheet, CueSheetStatus, DiscoveredCueSheets};
-pub use download::TrackedDownload;
+pub use cue::{CueSheet, CueSheetStatus, DiscoveredCueSheets, InputFile, InputFileKind};
+pub use download::{DownloadLifecycleState, TrackedDownload};
 pub use processing::{FailedImportCandidate, QueueSnapshot, SplitOutcome, SplitStatus};
-pub use track::GeneratedTrack;
+pub use track::{GeneratedTrack, RecordedTrack, TrackCleanupOutcome, TrackCleanupStatus};

--- a/src/domain/processing.rs
+++ b/src/domain/processing.rs
@@ -13,6 +13,7 @@ pub struct FailedImportCandidate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueueSnapshot {
     pub total_records: usize,
+    pub pages_fetched: usize,
     pub active_download_ids: HashSet<String>,
     pub failed_imports: Vec<FailedImportCandidate>,
 }

--- a/src/domain/track.rs
+++ b/src/domain/track.rs
@@ -4,4 +4,49 @@ pub struct GeneratedTrack {
     pub cue_sheet_id: String,
     pub download_id: String,
     pub path: String,
+    pub size_bytes: Option<i64>,
+    pub cleanup_status: TrackCleanupStatus,
+    pub cleanup_message: Option<String>,
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrackCleanupStatus {
+    Pending,
+    Deleted,
+    DeleteFailed,
+    Missing,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordedTrack {
+    pub path: String,
+    pub size_bytes: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackCleanupOutcome {
+    pub track_id: String,
+    pub status: TrackCleanupStatus,
+    pub message: Option<String>,
+}
+
+impl TrackCleanupStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Deleted => "deleted",
+            Self::DeleteFailed => "delete_failed",
+            Self::Missing => "missing",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Self {
+        match value {
+            "deleted" => Self::Deleted,
+            "delete_failed" => Self::DeleteFailed,
+            "missing" => Self::Missing,
+            _ => Self::Pending,
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,11 +46,39 @@ async fn main() -> Result<()> {
 
     println!("Web UI listening on http://{}", settings.server.bind_address);
 
-    tokio::spawn(async move {
-        if let Err(err) = service.run().await {
-            eprintln!("monitor exited: {err:#}");
-        }
-    });
+    spawn_monitor_thread(service).context("start monitor thread")?;
 
     axum::serve(listener, app).await.context("run web server")
+}
+
+fn spawn_monitor_thread<Q, S, C, P, X>(service: MonitorService<Q, S, C, P, X>) -> Result<()>
+where
+    Q: crate::application::ports::QueueSource + Send + 'static,
+    S: crate::application::ports::DownloadStore + Send + Sync + 'static,
+    C: crate::application::ports::CueScanner + Send + Sync + 'static,
+    P: crate::application::ports::CueSplitter + Send + Sync + 'static,
+    X: crate::application::ports::TrackCleanup + Send + Sync + 'static,
+{
+    std::thread::Builder::new()
+        .name("splittarr-monitor".into())
+        .spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(err) => {
+                    eprintln!("failed to create monitor runtime: {err:#}");
+                    return;
+                }
+            };
+
+            runtime.block_on(async move {
+                if let Err(err) = service.run().await {
+                    eprintln!("monitor exited: {err:#}");
+                }
+            });
+        })
+        .map(|_| ())
+        .map_err(Into::into)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,39 +49,14 @@ async fn main() -> Result<()> {
         settings.server.bind_address
     );
 
-    spawn_monitor_thread(service).context("start monitor thread")?;
+    let local = tokio::task::LocalSet::new();
+    local.spawn_local(async move {
+        if let Err(err) = service.run().await {
+            eprintln!("monitor exited: {err:#}");
+        }
+    });
 
-    axum::serve(listener, app).await.context("run web server")
-}
-
-fn spawn_monitor_thread<Q, S, C, P, X>(service: MonitorService<Q, S, C, P, X>) -> Result<()>
-where
-    Q: crate::application::ports::QueueSource + Send + 'static,
-    S: crate::application::ports::DownloadStore + Send + Sync + 'static,
-    C: crate::application::ports::CueScanner + Send + Sync + 'static,
-    P: crate::application::ports::CueSplitter + Send + Sync + 'static,
-    X: crate::application::ports::TrackCleanup + Send + Sync + 'static,
-{
-    std::thread::Builder::new()
-        .name("splittarr-monitor".into())
-        .spawn(move || {
-            let runtime = match tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                Ok(runtime) => runtime,
-                Err(err) => {
-                    eprintln!("failed to create monitor runtime: {err:#}");
-                    return;
-                }
-            };
-
-            runtime.block_on(async move {
-                if let Err(err) = service.run().await {
-                    eprintln!("monitor exited: {err:#}");
-                }
-            });
-        })
-        .map(|_| ())
-        .map_err(Into::into)
+    local
+        .run_until(async move { axum::serve(listener, app).await.context("run web server") })
+        .await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use crate::adapters::filesystem_cue_scanner::FilesystemCueScanner;
 use crate::adapters::lidarr_api::LidarrQueueSource;
 use crate::adapters::shnsplit_splitter::ShnsplitCueSplitter;
 use crate::adapters::sqlite_download_store::SqliteDownloadStore;
+use crate::adapters::web;
 use crate::application::service::MonitorService;
 use crate::bootstrap::settings::{Cli, Settings};
 
@@ -21,6 +22,7 @@ async fn main() -> Result<()> {
     let queue_source = LidarrQueueSource::new(&settings.lidarr);
     let download_store =
         SqliteDownloadStore::open(&settings.data_dir).context("initialize Splittarr database")?;
+    let web_store = download_store.clone();
     let cue_scanner = FilesystemCueScanner::new();
     let cue_splitter = ShnsplitCueSplitter::new(
         settings.cue.strict,
@@ -37,6 +39,18 @@ async fn main() -> Result<()> {
         track_cleanup,
         settings.check_frequency_seconds,
     );
+    let listener = tokio::net::TcpListener::bind(&settings.server.bind_address)
+        .await
+        .with_context(|| format!("bind {}", settings.server.bind_address))?;
+    let app = web::router(web_store);
 
-    service.run().await
+    println!("Web UI listening on http://{}", settings.server.bind_address);
+
+    tokio::spawn(async move {
+        if let Err(err) = service.run().await {
+            eprintln!("monitor exited: {err:#}");
+        }
+    });
+
+    axum::serve(listener, app).await.context("run web server")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,10 @@ async fn main() -> Result<()> {
         .with_context(|| format!("bind {}", settings.server.bind_address))?;
     let app = web::router(web_store);
 
-    println!("Web UI listening on http://{}", settings.server.bind_address);
+    println!(
+        "Web UI listening on http://{}",
+        settings.server.bind_address
+    );
 
     spawn_monitor_thread(service).context("start monitor thread")?;
 


### PR DESCRIPTION
## Summary
- retain tracked downloads in SQLite with explicit lifecycle states instead of deleting rows after cleanup
- add file snapshot and cleanup metadata plus schema migrations for persistent download history
- serve an embedded Axum/Maud monitoring UI with list and detail pages for tracked downloads

## Verification
- cargo test -- --nocapture
- cargo build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in web UI for monitoring download history with live-updating index and per-download detail views

* **Configuration**
  * Added server bind address setting (default: 127.0.0.1:9899) with env var override
  * Added Lidarr queue pagination controls (page size / max pages)

* **Improvements**
  * Persist full processing history (input snapshots, cue results, generated track metadata, sizes, errors)
  * Record per-track cleanup outcomes (Deleted / Missing / DeleteFailed) and retain tracked downloads instead of deleting them

* **Documentation**
  * README expanded with web UI routes, config examples, and updated cleanup/database behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->