### PR TITLE
refactor(application): extract cue input inspector

### DIFF
--- a/src/adapters/filesystem_cue_input_inspector.rs
+++ b/src/adapters/filesystem_cue_input_inspector.rs
@@ -1,0 +1,206 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+use rcue::parser::parse_from_file;
+
+use crate::application::ports::{CueInputInspector, CueInputSnapshot, CueReferencedAudioInput};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FilesystemCueInputInspector;
+
+impl FilesystemCueInputInspector {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl CueInputInspector for FilesystemCueInputInspector {
+    async fn snapshot_inputs(&self, cue_path: &Path) -> Result<CueInputSnapshot> {
+        let cue_path = cue_path.to_path_buf();
+        tokio::task::spawn_blocking(move || snapshot_inputs_sync(&cue_path))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn cue_references_audio_file(&self, cue_path: &Path, audio_path: &Path) -> Result<bool> {
+        let cue_path = cue_path.to_path_buf();
+        let audio_path = audio_path.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            Ok(cue_references_audio_file_sync(&cue_path, &audio_path))
+        })
+        .await
+        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+}
+
+fn snapshot_inputs_sync(cue_path: &Path) -> Result<CueInputSnapshot> {
+    let cue_size_bytes = file_size(cue_path);
+    let cue = match parse_from_file(&cue_path.to_string_lossy(), false) {
+        Ok(cue) => cue,
+        Err(err) => {
+            eprintln!(
+                "Unable to parse cue file for input snapshot {}: {err}",
+                cue_path.display()
+            );
+            return Ok(CueInputSnapshot {
+                cue_size_bytes,
+                audio_inputs: Vec::new(),
+            });
+        }
+    };
+    let cue_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
+    let audio_inputs = cue
+        .files
+        .iter()
+        .map(|file| cue_dir.join(&file.file))
+        .filter_map(existing_audio_input)
+        .collect();
+
+    Ok(CueInputSnapshot {
+        cue_size_bytes,
+        audio_inputs,
+    })
+}
+
+fn cue_references_audio_file_sync(cue_path: &Path, audio_path: &Path) -> bool {
+    let cue = match parse_from_file(&cue_path.to_string_lossy(), false) {
+        Ok(cue) => cue,
+        Err(err) => {
+            eprintln!(
+                "Unable to parse cue file while matching audio {}: {err}",
+                cue_path.display()
+            );
+            return false;
+        }
+    };
+    let cue_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
+
+    cue.files
+        .iter()
+        .map(|file| cue_dir.join(&file.file))
+        .any(|candidate| candidate == audio_path)
+}
+
+fn existing_audio_input(path: PathBuf) -> Option<CueReferencedAudioInput> {
+    path.exists().then(|| CueReferencedAudioInput {
+        path: path.clone(),
+        size_bytes: file_size(&path),
+    })
+}
+
+fn file_size(path: &Path) -> Option<i64> {
+    fs::metadata(path)
+        .ok()
+        .and_then(|metadata| i64::try_from(metadata.len()).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::FilesystemCueInputInspector;
+    use crate::application::ports::{CueInputInspector, CueReferencedAudioInput};
+
+    #[tokio::test]
+    async fn snapshot_inputs_returns_cue_size_and_existing_audio_inputs() {
+        let tmp = tempdir().unwrap();
+        let cue_path = tmp.path().join("album.cue");
+        let audio_path = tmp.path().join("album.flac");
+        fs::write(
+            &cue_path,
+            "FILE \"album.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"Track\"\n    INDEX 01 00:00:00\n",
+        )
+        .unwrap();
+        fs::write(&audio_path, b"audio").unwrap();
+
+        let snapshot = FilesystemCueInputInspector::new()
+            .snapshot_inputs(&cue_path)
+            .await
+            .unwrap();
+
+        assert!(snapshot.cue_size_bytes.is_some());
+        assert_eq!(
+            snapshot.audio_inputs,
+            vec![CueReferencedAudioInput {
+                path: audio_path,
+                size_bytes: Some(5),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_inputs_skips_missing_referenced_audio() {
+        let tmp = tempdir().unwrap();
+        let cue_path = tmp.path().join("album.cue");
+        fs::write(
+            &cue_path,
+            "FILE \"missing.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"Track\"\n    INDEX 01 00:00:00\n",
+        )
+        .unwrap();
+
+        let snapshot = FilesystemCueInputInspector::new()
+            .snapshot_inputs(&cue_path)
+            .await
+            .unwrap();
+
+        assert!(snapshot.cue_size_bytes.is_some());
+        assert!(snapshot.audio_inputs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn snapshot_inputs_returns_empty_audio_inputs_for_invalid_cue() {
+        let tmp = tempdir().unwrap();
+        let cue_path = tmp.path().join("broken.cue");
+        fs::write(&cue_path, "not a cue").unwrap();
+
+        let snapshot = FilesystemCueInputInspector::new()
+            .snapshot_inputs(&cue_path)
+            .await
+            .unwrap();
+
+        assert!(snapshot.cue_size_bytes.is_some());
+        assert!(snapshot.audio_inputs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cue_matching_checks_exact_referenced_audio_file() {
+        let tmp = tempdir().unwrap();
+        let target_audio = tmp.path().join("target.flac");
+        let other_audio = tmp.path().join("other.flac");
+        let cue_path = tmp.path().join("target.cue");
+        fs::write(&target_audio, b"audio").unwrap();
+        fs::write(
+            &cue_path,
+            "FILE \"target.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"Track\"\n    INDEX 01 00:00:00\n",
+        )
+        .unwrap();
+
+        let inspector = FilesystemCueInputInspector::new();
+        assert!(inspector
+            .cue_references_audio_file(&cue_path, &target_audio)
+            .await
+            .unwrap());
+        assert!(!inspector
+            .cue_references_audio_file(&cue_path, &other_audio)
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn invalid_cue_matching_returns_false() {
+        let tmp = tempdir().unwrap();
+        let cue_path = tmp.path().join("broken.cue");
+        let audio_path = tmp.path().join("target.flac");
+        fs::write(&cue_path, "not a cue").unwrap();
+
+        let matches = FilesystemCueInputInspector::new()
+            .cue_references_audio_file(&cue_path, &audio_path)
+            .await
+            .unwrap();
+
+        assert!(!matches);
+    }
+}

--- a/src/adapters/filesystem_cue_input_inspector.rs
+++ b/src/adapters/filesystem_cue_input_inspector.rs
@@ -18,9 +18,9 @@ impl FilesystemCueInputInspector {
 impl CueInputInspector for FilesystemCueInputInspector {
     async fn file_size(&self, path: &Path) -> Result<Option<i64>> {
         let path = path.to_path_buf();
-        tokio::task::spawn_blocking(move || Ok(file_size(&path)))
+        tokio::task::spawn_blocking(move || file_size(&path))
             .await
-            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))
     }
 
     async fn snapshot_inputs(&self, cue_path: &Path) -> Result<CueInputSnapshot> {
@@ -33,11 +33,9 @@ impl CueInputInspector for FilesystemCueInputInspector {
     async fn cue_references_audio_file(&self, cue_path: &Path, audio_path: &Path) -> Result<bool> {
         let cue_path = cue_path.to_path_buf();
         let audio_path = audio_path.to_path_buf();
-        tokio::task::spawn_blocking(move || {
-            Ok(cue_references_audio_file_sync(&cue_path, &audio_path))
-        })
+        tokio::task::spawn_blocking(move || cue_references_audio_file_sync(&cue_path, &audio_path))
         .await
-        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+        .map_err(|err| anyhow!("blocking task failed to join: {err}"))
     }
 
     async fn filter_cue_files_for_audio(
@@ -46,11 +44,9 @@ impl CueInputInspector for FilesystemCueInputInspector {
         audio_path: &Path,
     ) -> Result<Vec<PathBuf>> {
         let audio_path = audio_path.to_path_buf();
-        tokio::task::spawn_blocking(move || {
-            Ok(filter_cue_files_for_audio_sync(cue_files, &audio_path))
-        })
+        tokio::task::spawn_blocking(move || filter_cue_files_for_audio_sync(cue_files, &audio_path))
         .await
-        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+        .map_err(|err| anyhow!("blocking task failed to join: {err}"))
     }
 }
 

--- a/src/adapters/filesystem_cue_input_inspector.rs
+++ b/src/adapters/filesystem_cue_input_inspector.rs
@@ -39,6 +39,22 @@ impl CueInputInspector for FilesystemCueInputInspector {
         .await
         .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
+
+    async fn filter_cue_files_for_audio(
+        &self,
+        cue_files: Vec<PathBuf>,
+        audio_path: &Path,
+    ) -> Result<Vec<PathBuf>> {
+        let audio_path = audio_path.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            Ok(cue_files
+                .into_iter()
+                .filter(|cue_path| cue_references_audio_file_sync(cue_path, &audio_path))
+                .collect())
+        })
+        .await
+        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
 }
 
 fn snapshot_inputs_sync(cue_path: &Path) -> Result<CueInputSnapshot> {

--- a/src/adapters/filesystem_cue_input_inspector.rs
+++ b/src/adapters/filesystem_cue_input_inspector.rs
@@ -106,9 +106,10 @@ fn cue_references_audio_file_sync(cue_path: &Path, audio_path: &Path) -> bool {
 }
 
 fn existing_audio_input(path: PathBuf) -> Option<CueReferencedAudioInput> {
-    path.exists().then(|| CueReferencedAudioInput {
-        path: path.clone(),
-        size_bytes: file_size(&path),
+    let metadata = fs::metadata(&path).ok()?;
+    Some(CueReferencedAudioInput {
+        path,
+        size_bytes: i64::try_from(metadata.len()).ok(),
     })
 }
 

--- a/src/adapters/filesystem_cue_input_inspector.rs
+++ b/src/adapters/filesystem_cue_input_inspector.rs
@@ -47,10 +47,7 @@ impl CueInputInspector for FilesystemCueInputInspector {
     ) -> Result<Vec<PathBuf>> {
         let audio_path = audio_path.to_path_buf();
         tokio::task::spawn_blocking(move || {
-            Ok(cue_files
-                .into_iter()
-                .filter(|cue_path| cue_references_audio_file_sync(cue_path, &audio_path))
-                .collect())
+            Ok(filter_cue_files_for_audio_sync(cue_files, &audio_path))
         })
         .await
         .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
@@ -103,6 +100,13 @@ fn cue_references_audio_file_sync(cue_path: &Path, audio_path: &Path) -> bool {
         .iter()
         .map(|file| cue_dir.join(&file.file))
         .any(|candidate| candidate == audio_path)
+}
+
+fn filter_cue_files_for_audio_sync(cue_files: Vec<PathBuf>, audio_path: &Path) -> Vec<PathBuf> {
+    cue_files
+        .into_iter()
+        .filter(|cue_path| cue_references_audio_file_sync(cue_path, audio_path))
+        .collect()
 }
 
 fn existing_audio_input(path: PathBuf) -> Option<CueReferencedAudioInput> {

--- a/src/adapters/filesystem_cue_input_inspector.rs
+++ b/src/adapters/filesystem_cue_input_inspector.rs
@@ -16,6 +16,13 @@ impl FilesystemCueInputInspector {
 }
 
 impl CueInputInspector for FilesystemCueInputInspector {
+    async fn file_size(&self, path: &Path) -> Result<Option<i64>> {
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || Ok(file_size(&path)))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
     async fn snapshot_inputs(&self, cue_path: &Path) -> Result<CueInputSnapshot> {
         let cue_path = cue_path.to_path_buf();
         tokio::task::spawn_blocking(move || snapshot_inputs_sync(&cue_path))

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,4 +1,5 @@
 pub mod filesystem_cleanup;
+pub mod filesystem_cue_input_inspector;
 pub mod filesystem_cue_scanner;
 pub mod lidarr_api;
 pub mod shnsplit_splitter;

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -91,6 +91,7 @@ pub struct CueReferencedAudioInput {
 }
 
 pub trait CueInputInspector {
+    async fn file_size(&self, path: &Path) -> Result<Option<i64>>;
     async fn snapshot_inputs(&self, cue_path: &Path) -> Result<CueInputSnapshot>;
     async fn cue_references_audio_file(&self, cue_path: &Path, audio_path: &Path) -> Result<bool>;
 }

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -94,6 +94,22 @@ pub trait CueInputInspector {
     async fn file_size(&self, path: &Path) -> Result<Option<i64>>;
     async fn snapshot_inputs(&self, cue_path: &Path) -> Result<CueInputSnapshot>;
     async fn cue_references_audio_file(&self, cue_path: &Path, audio_path: &Path) -> Result<bool>;
+    async fn filter_cue_files_for_audio(
+        &self,
+        cue_files: Vec<PathBuf>,
+        audio_path: &Path,
+    ) -> Result<Vec<PathBuf>> {
+        let mut matching = Vec::new();
+        for cue_path in cue_files {
+            if self
+                .cue_references_audio_file(&cue_path, audio_path)
+                .await?
+            {
+                matching.push(cue_path);
+            }
+        }
+        Ok(matching)
+    }
 }
 
 pub trait CueSplitter {

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
@@ -76,6 +76,23 @@ pub trait DownloadStore {
 
 pub trait CueScanner {
     async fn find_cue_sheets(&self, root: &Path) -> Result<DiscoveredCueSheets>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CueInputSnapshot {
+    pub cue_size_bytes: Option<i64>,
+    pub audio_inputs: Vec<CueReferencedAudioInput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CueReferencedAudioInput {
+    pub path: PathBuf,
+    pub size_bytes: Option<i64>,
+}
+
+pub trait CueInputInspector {
+    async fn snapshot_inputs(&self, cue_path: &Path) -> Result<CueInputSnapshot>;
+    async fn cue_references_audio_file(&self, cue_path: &Path, audio_path: &Path) -> Result<bool>;
 }
 
 pub trait CueSplitter {

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -61,8 +61,9 @@ where
     let mut scan = scanner.find_cue_sheets(&scan_root).await?;
 
     if output_path.is_file() {
-        scan.cue_files =
-            filter_cue_files_for_audio(inspector, scan.cue_files, &output_path).await?;
+        scan.cue_files = inspector
+            .filter_cue_files_for_audio(scan.cue_files, &output_path)
+            .await?;
     }
 
     for error in &scan.errors {
@@ -198,23 +199,6 @@ fn scan_root_for(output_path: &Path) -> Result<PathBuf> {
         });
     }
     Ok(output_path.to_path_buf())
-}
-
-async fn filter_cue_files_for_audio<I: CueInputInspector>(
-    inspector: &I,
-    cue_files: Vec<PathBuf>,
-    audio_path: &Path,
-) -> Result<Vec<PathBuf>> {
-    let mut matching = Vec::new();
-    for cue_path in cue_files {
-        if inspector
-            .cue_references_audio_file(&cue_path, audio_path)
-            .await?
-        {
-            matching.push(cue_path);
-        }
-    }
-    Ok(matching)
 }
 
 #[cfg(test)]

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -2,10 +2,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
-use rcue::parser::parse_from_file;
-use tokio::task;
 
-use crate::application::ports::{CueScanner, CueSplitter, DownloadStore};
+use crate::application::ports::{CueInputInspector, CueScanner, CueSplitter, DownloadStore};
 use crate::domain::{
     CueSheet, CueSheetStatus, FailedImportCandidate, InputFileKind, RecordedTrack, SplitOutcome,
     SplitStatus, TrackedDownload,
@@ -43,15 +41,17 @@ pub async fn register_failed_imports<S: DownloadStore>(
     Ok(())
 }
 
-pub async fn process_tracked_download<S, C, P>(
+pub async fn process_tracked_download<S, C, I, P>(
     store: &S,
     scanner: &C,
+    inspector: &I,
     splitter: &P,
     download: TrackedDownload,
 ) -> Result<()>
 where
     S: DownloadStore,
     C: CueScanner,
+    I: CueInputInspector,
     P: CueSplitter,
 {
     store
@@ -62,7 +62,8 @@ where
     let mut scan = scanner.find_cue_sheets(&scan_root).await?;
 
     if output_path.is_file() {
-        scan.cue_files = filter_cue_files_for_audio(scan.cue_files, output_path.clone()).await?;
+        scan.cue_files =
+            filter_cue_files_for_audio(inspector, scan.cue_files, &output_path).await?;
     }
 
     for error in &scan.errors {
@@ -83,7 +84,14 @@ where
         let cue_sheet = store
             .get_or_create_cue_sheet(&download.download_id, &cue_path)
             .await?;
-        snapshot_input_files(store, &download.download_id, &cue_sheet, &cue_path).await?;
+        snapshot_input_files(
+            store,
+            inspector,
+            &download.download_id,
+            &cue_sheet,
+            &cue_path,
+        )
+        .await?;
 
         if cue_sheet.status.is_terminal_success() {
             continue;
@@ -145,13 +153,14 @@ async fn store_split_result<S: DownloadStore>(
         .await
 }
 
-async fn snapshot_input_files<S: DownloadStore>(
+async fn snapshot_input_files<S: DownloadStore, I: CueInputInspector>(
     store: &S,
+    inspector: &I,
     download_id: &str,
     cue_sheet: &CueSheet,
     cue_path: &Path,
 ) -> Result<()> {
-    let snapshot = snapshot_input_file_details(cue_path.to_path_buf()).await?;
+    let snapshot = inspector.snapshot_inputs(cue_path).await?;
     store
         .record_input_file(
             download_id,
@@ -177,57 +186,6 @@ async fn snapshot_input_files<S: DownloadStore>(
     Ok(())
 }
 
-struct SnapshotInputDetails {
-    cue_size_bytes: Option<i64>,
-    audio_inputs: Vec<SnapshotAudioInput>,
-}
-
-struct SnapshotAudioInput {
-    path: PathBuf,
-    size_bytes: Option<i64>,
-}
-
-async fn snapshot_input_file_details(cue_path: PathBuf) -> Result<SnapshotInputDetails> {
-    task::spawn_blocking(move || snapshot_input_file_details_sync(&cue_path))
-        .await
-        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
-}
-
-fn snapshot_input_file_details_sync(cue_path: &Path) -> Result<SnapshotInputDetails> {
-    let cue_size_bytes = file_size(cue_path);
-    let cue_path_str = cue_path.to_string_lossy();
-    let cue = match parse_from_file(&cue_path_str, false) {
-        Ok(cue) => cue,
-        Err(err) => {
-            eprintln!(
-                "Unable to parse cue file for input snapshot {}: {err}",
-                cue_path.display()
-            );
-            return Ok(SnapshotInputDetails {
-                cue_size_bytes,
-                audio_inputs: Vec::new(),
-            });
-        }
-    };
-    let cue_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
-    let audio_inputs = cue
-        .files
-        .iter()
-        .map(|file| cue_dir.join(&file.file))
-        .filter_map(|path| {
-            path.exists().then(|| SnapshotAudioInput {
-                size_bytes: file_size(&path),
-                path,
-            })
-        })
-        .collect();
-
-    Ok(SnapshotInputDetails {
-        cue_size_bytes,
-        audio_inputs,
-    })
-}
-
 fn file_size(path: &Path) -> Option<i64> {
     fs::metadata(path)
         .ok()
@@ -249,37 +207,21 @@ fn scan_root_for(output_path: &Path) -> Result<PathBuf> {
     Ok(output_path.to_path_buf())
 }
 
-fn cue_references_audio_file(cue_path: &Path, audio_path: &Path) -> bool {
-    let cue = match parse_from_file(&cue_path.to_string_lossy(), false) {
-        Ok(cue) => cue,
-        Err(err) => {
-            eprintln!(
-                "Unable to parse cue file while matching audio {}: {err}",
-                cue_path.display()
-            );
-            return false;
-        }
-    };
-    let cue_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
-
-    cue.files
-        .iter()
-        .map(|file| cue_dir.join(&file.file))
-        .any(|candidate| candidate == audio_path)
-}
-
-async fn filter_cue_files_for_audio(
+async fn filter_cue_files_for_audio<I: CueInputInspector>(
+    inspector: &I,
     cue_files: Vec<PathBuf>,
-    audio_path: PathBuf,
+    audio_path: &Path,
 ) -> Result<Vec<PathBuf>> {
-    task::spawn_blocking(move || {
-        Ok(cue_files
-            .into_iter()
-            .filter(|cue_path| cue_references_audio_file(cue_path, &audio_path))
-            .collect())
-    })
-    .await
-    .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    let mut matching = Vec::new();
+    for cue_path in cue_files {
+        if inspector
+            .cue_references_audio_file(&cue_path, audio_path)
+            .await?
+        {
+            matching.push(cue_path);
+        }
+    }
+    Ok(matching)
 }
 
 #[cfg(test)]
@@ -291,8 +233,11 @@ mod tests {
     use anyhow::Result;
     use tempfile::tempdir;
 
-    use super::{cue_references_audio_file, process_tracked_download};
-    use crate::application::ports::{CueScanner, CueSplitter, DownloadStore};
+    use super::process_tracked_download;
+    use crate::application::ports::{
+        CueInputInspector, CueInputSnapshot, CueReferencedAudioInput, CueScanner, CueSplitter,
+        DownloadStore,
+    };
     use crate::domain::{
         CueSheet, CueSheetStatus, DiscoveredCueSheets, InputFileKind, RecordedTrack, SplitOutcome,
         SplitStatus, TrackCleanupStatus, TrackedDownload,
@@ -431,6 +376,43 @@ mod tests {
         }
     }
 
+    struct FakeInspector {
+        matches: Mutex<Vec<(PathBuf, PathBuf)>>,
+    }
+
+    impl CueInputInspector for FakeInspector {
+        async fn snapshot_inputs(&self, cue_path: &Path) -> Result<CueInputSnapshot> {
+            let cue_size_bytes = fs::metadata(cue_path)
+                .ok()
+                .and_then(|metadata| i64::try_from(metadata.len()).ok());
+            let audio_path = cue_path.with_extension("flac");
+            let audio_inputs = if audio_path.exists() {
+                vec![CueReferencedAudioInput {
+                    path: audio_path,
+                    size_bytes: Some(5),
+                }]
+            } else {
+                Vec::new()
+            };
+            Ok(CueInputSnapshot {
+                cue_size_bytes,
+                audio_inputs,
+            })
+        }
+
+        async fn cue_references_audio_file(
+            &self,
+            cue_path: &Path,
+            audio_path: &Path,
+        ) -> Result<bool> {
+            self.matches
+                .lock()
+                .unwrap()
+                .push((cue_path.to_path_buf(), audio_path.to_path_buf()));
+            Ok(cue_path.file_stem() == audio_path.file_stem())
+        }
+    }
+
     struct FakeSplitter {
         calls: Mutex<Vec<PathBuf>>,
     }
@@ -463,6 +445,9 @@ mod tests {
             roots: Mutex::new(Vec::new()),
             cue_files: vec![cue_path.clone()],
         };
+        let inspector = FakeInspector {
+            matches: Mutex::new(Vec::new()),
+        };
         let splitter = FakeSplitter {
             calls: Mutex::new(Vec::new()),
         };
@@ -474,7 +459,7 @@ mod tests {
             "importFailed".into(),
         );
 
-        process_tracked_download(&store, &scanner, &splitter, download)
+        process_tracked_download(&store, &scanner, &inspector, &splitter, download)
             .await
             .unwrap();
 
@@ -507,6 +492,9 @@ mod tests {
             roots: Mutex::new(Vec::new()),
             cue_files: vec![cue_path],
         };
+        let inspector = FakeInspector {
+            matches: Mutex::new(Vec::new()),
+        };
         let splitter = FakeSplitter {
             calls: Mutex::new(Vec::new()),
         };
@@ -518,7 +506,7 @@ mod tests {
             "importFailed".into(),
         );
 
-        process_tracked_download(&store, &scanner, &splitter, download)
+        process_tracked_download(&store, &scanner, &inspector, &splitter, download)
             .await
             .unwrap();
 
@@ -554,6 +542,9 @@ mod tests {
             roots: Mutex::new(Vec::new()),
             cue_files: vec![other_cue, target_cue.clone()],
         };
+        let inspector = FakeInspector {
+            matches: Mutex::new(Vec::new()),
+        };
         let splitter = FakeSplitter {
             calls: Mutex::new(Vec::new()),
         };
@@ -565,28 +556,11 @@ mod tests {
             "importFailed".into(),
         );
 
-        process_tracked_download(&store, &scanner, &splitter, download)
+        process_tracked_download(&store, &scanner, &inspector, &splitter, download)
             .await
             .unwrap();
 
         assert_eq!(splitter.calls.lock().unwrap().as_slice(), &[target_cue]);
-    }
-
-    #[test]
-    fn cue_matching_checks_exact_referenced_audio_file() {
-        let tmp = tempdir().unwrap();
-        let target_audio = tmp.path().join("target.flac");
-        let target_cue = tmp.path().join("target.cue");
-        let other_audio = tmp.path().join("other.flac");
-        fs::write(&target_audio, b"audio").unwrap();
-        fs::write(
-            &target_cue,
-            "FILE \"target.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"Track\"\n    INDEX 01 00:00:00\n",
-        )
-        .unwrap();
-
-        assert!(cue_references_audio_file(&target_cue, &target_audio));
-        assert!(!cue_references_audio_file(&target_cue, &other_audio));
     }
 
     #[tokio::test]
@@ -600,6 +574,9 @@ mod tests {
             roots: Mutex::new(Vec::new()),
             cue_files: vec![cue_path.clone()],
         };
+        let inspector = FakeInspector {
+            matches: Mutex::new(Vec::new()),
+        };
         let splitter = FakeSplitter {
             calls: Mutex::new(Vec::new()),
         };
@@ -611,11 +588,14 @@ mod tests {
             "importFailed".into(),
         );
 
-        process_tracked_download(&store, &scanner, &splitter, download)
+        process_tracked_download(&store, &scanner, &inspector, &splitter, download)
             .await
             .unwrap();
 
-        assert_eq!(splitter.calls.lock().unwrap().as_slice(), &[cue_path.clone()]);
+        assert_eq!(
+            splitter.calls.lock().unwrap().as_slice(),
+            &[cue_path.clone()]
+        );
         assert_eq!(
             store.recorded_input_files.lock().unwrap().as_slice(),
             &[(cue_path.to_string_lossy().to_string(), InputFileKind::Cue)]

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
@@ -99,7 +98,7 @@ where
 
         match splitter.split_cue(&cue_path).await {
             Ok(result) => {
-                store_split_result(store, &cue_sheet, result).await?;
+                store_split_result(store, inspector, &cue_sheet, result).await?;
             }
             Err(err) => {
                 all_cues_complete = false;
@@ -131,8 +130,9 @@ where
     Ok(())
 }
 
-async fn store_split_result<S: DownloadStore>(
+async fn store_split_result<S: DownloadStore, I: CueInputInspector>(
     store: &S,
+    inspector: &I,
     cue_sheet: &CueSheet,
     result: SplitOutcome,
 ) -> Result<()> {
@@ -140,14 +140,13 @@ async fn store_split_result<S: DownloadStore>(
         SplitStatus::Split => CueSheetStatus::Split,
         SplitStatus::Skipped => CueSheetStatus::Skipped,
     };
-    let tracks = result
-        .tracks
-        .iter()
-        .map(|path| RecordedTrack {
+    let mut tracks = Vec::with_capacity(result.tracks.len());
+    for path in &result.tracks {
+        tracks.push(RecordedTrack {
             path: path.to_string_lossy().to_string(),
-            size_bytes: file_size(path),
-        })
-        .collect::<Vec<_>>();
+            size_bytes: inspector.file_size(path).await?,
+        });
+    }
     store
         .record_cue_result(cue_sheet, status, result.message.as_deref(), &tracks)
         .await
@@ -184,12 +183,6 @@ async fn snapshot_input_files<S: DownloadStore, I: CueInputInspector>(
     }
 
     Ok(())
-}
-
-fn file_size(path: &Path) -> Option<i64> {
-    fs::metadata(path)
-        .ok()
-        .and_then(|metadata| i64::try_from(metadata.len()).ok())
 }
 
 fn scan_root_for(output_path: &Path) -> Result<PathBuf> {
@@ -381,6 +374,12 @@ mod tests {
     }
 
     impl CueInputInspector for FakeInspector {
+        async fn file_size(&self, path: &Path) -> Result<Option<i64>> {
+            Ok(fs::metadata(path)
+                .ok()
+                .and_then(|metadata| i64::try_from(metadata.len()).ok()))
+        }
+
         async fn snapshot_inputs(&self, cue_path: &Path) -> Result<CueInputSnapshot> {
             let cue_size_bytes = fs::metadata(cue_path)
                 .ok()

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -6,26 +6,29 @@ use chrono::prelude::*;
 use crate::application::cleanup_processed_download::cleanup_processed_download;
 use crate::application::monitor_download_queue::classify_downloads;
 use crate::application::ports::{
-    CueScanner, CueSplitter, DownloadStore, QueueSource, TrackCleanup,
+    CueInputInspector, CueScanner, CueSplitter,
+    DownloadStore, QueueSource, TrackCleanup,
 };
 use crate::application::process_tracked_download::{
     process_tracked_download, register_failed_imports,
 };
 
-pub struct MonitorService<Q, S, C, P, X> {
+pub struct MonitorService<Q, S, C, I, P, X> {
     queue_source: Q,
     download_store: S,
     cue_scanner: C,
+    cue_input_inspector: I,
     cue_splitter: P,
     track_cleanup: X,
     check_frequency_seconds: u64,
 }
 
-impl<Q, S, C, P, X> MonitorService<Q, S, C, P, X> {
+impl<Q, S, C, I, P, X> MonitorService<Q, S, C, I, P, X> {
     pub fn new(
         queue_source: Q,
         download_store: S,
         cue_scanner: C,
+        cue_input_inspector: I,
         cue_splitter: P,
         track_cleanup: X,
         check_frequency_seconds: u64,
@@ -34,6 +37,7 @@ impl<Q, S, C, P, X> MonitorService<Q, S, C, P, X> {
             queue_source,
             download_store,
             cue_scanner,
+            cue_input_inspector,
             cue_splitter,
             track_cleanup,
             check_frequency_seconds,
@@ -41,11 +45,12 @@ impl<Q, S, C, P, X> MonitorService<Q, S, C, P, X> {
     }
 }
 
-impl<Q, S, C, P, X> MonitorService<Q, S, C, P, X>
+impl<Q, S, C, I, P, X> MonitorService<Q, S, C, I, P, X>
 where
     Q: QueueSource,
     S: DownloadStore,
     C: CueScanner,
+    I: CueInputInspector,
     P: CueSplitter,
     X: TrackCleanup,
 {
@@ -109,6 +114,7 @@ where
             if let Err(err) = process_tracked_download(
                 &self.download_store,
                 &self.cue_scanner,
+                &self.cue_input_inspector,
                 &self.cue_splitter,
                 download.clone(),
             )
@@ -148,10 +154,12 @@ mod tests {
     use super::MonitorService;
     use crate::adapters::sqlite_download_store::SqliteDownloadStore;
     use crate::application::ports::{
-        CueScanner, CueSplitter, DownloadStore, QueueSource, TrackCleanup,
+        CueInputInspector, CueInputSnapshot, CueReferencedAudioInput, CueScanner, CueSplitter,
+        DownloadStore, QueueSource, TrackCleanup,
     };
     use crate::domain::{
-        DiscoveredCueSheets, DownloadLifecycleState, FailedImportCandidate, QueueSnapshot, SplitOutcome, SplitStatus, TrackCleanupOutcome, TrackCleanupStatus,
+        DiscoveredCueSheets, DownloadLifecycleState, FailedImportCandidate, QueueSnapshot,
+        SplitOutcome, SplitStatus, TrackCleanupOutcome, TrackCleanupStatus,
     };
 
     struct FakeQueue {
@@ -179,6 +187,30 @@ mod tests {
                 cue_files: vec![self.cue_path.clone()],
                 errors: Vec::new(),
             })
+        }
+    }
+
+    struct FakeInspector;
+
+    impl CueInputInspector for FakeInspector {
+        async fn snapshot_inputs(&self, cue_path: &Path) -> anyhow::Result<CueInputSnapshot> {
+            Ok(CueInputSnapshot {
+                cue_size_bytes: fs::metadata(cue_path)
+                    .ok()
+                    .and_then(|metadata| i64::try_from(metadata.len()).ok()),
+                audio_inputs: vec![CueReferencedAudioInput {
+                    path: cue_path.with_extension("flac"),
+                    size_bytes: Some(5),
+                }],
+            })
+        }
+
+        async fn cue_references_audio_file(
+            &self,
+            cue_path: &Path,
+            audio_path: &Path,
+        ) -> anyhow::Result<bool> {
+            Ok(cue_path.file_stem() == audio_path.file_stem())
         }
     }
 
@@ -267,6 +299,7 @@ FILE "album.flac" WAVE
             FakeScanner {
                 cue_path: cue_path.clone(),
             },
+            FakeInspector,
             FakeSplitter {
                 output_track: split_track.clone(),
             },

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -193,6 +193,12 @@ mod tests {
     struct FakeInspector;
 
     impl CueInputInspector for FakeInspector {
+        async fn file_size(&self, path: &Path) -> anyhow::Result<Option<i64>> {
+            Ok(fs::metadata(path)
+                .ok()
+                .and_then(|metadata| i64::try_from(metadata.len()).ok()))
+        }
+
         async fn snapshot_inputs(&self, cue_path: &Path) -> anyhow::Result<CueInputSnapshot> {
             Ok(CueInputSnapshot {
                 cue_size_bytes: fs::metadata(cue_path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 
 use crate::adapters::filesystem_cleanup::FilesystemTrackCleanup;
+use crate::adapters::filesystem_cue_input_inspector::FilesystemCueInputInspector;
 use crate::adapters::filesystem_cue_scanner::FilesystemCueScanner;
 use crate::adapters::lidarr_api::LidarrQueueSource;
 use crate::adapters::shnsplit_splitter::ShnsplitCueSplitter;
@@ -24,6 +25,7 @@ async fn main() -> Result<()> {
         SqliteDownloadStore::open(&settings.data_dir).context("initialize Splittarr database")?;
     let web_store = download_store.clone();
     let cue_scanner = FilesystemCueScanner::new();
+    let cue_input_inspector = FilesystemCueInputInspector::new();
     let cue_splitter = ShnsplitCueSplitter::new(
         settings.cue.strict,
         settings.shnsplit.path.clone(),
@@ -35,6 +37,7 @@ async fn main() -> Result<()> {
         queue_source,
         download_store,
         cue_scanner,
+        cue_input_inspector,
         cue_splitter,
         track_cleanup,
         settings.check_frequency_seconds,


### PR DESCRIPTION
## Summary
- add a dedicated `CueInputInspector` application port for cue snapshotting and cue-to-audio matching
- move filesystem and `rcue` inspection into a new filesystem-backed adapter
- update orchestration tests to use the new seam and add focused adapter coverage

Closes #16 

## Verification
- rtk cargo test -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cue file validation to ensure referenced audio files exist on the filesystem.
  * Implemented automatic metadata tracking for cue files and associated audio files, including size information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->