### PR TITLE
fix(processing): log split failures

### DIFF
--- a/src/adapters/filesystem_cue_input_inspector.rs
+++ b/src/adapters/filesystem_cue_input_inspector.rs
@@ -34,8 +34,8 @@ impl CueInputInspector for FilesystemCueInputInspector {
         let cue_path = cue_path.to_path_buf();
         let audio_path = audio_path.to_path_buf();
         tokio::task::spawn_blocking(move || cue_references_audio_file_sync(&cue_path, &audio_path))
-        .await
-        .map_err(|err| anyhow!("blocking task failed to join: {err}"))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))
     }
 
     async fn filter_cue_files_for_audio(
@@ -45,8 +45,8 @@ impl CueInputInspector for FilesystemCueInputInspector {
     ) -> Result<Vec<PathBuf>> {
         let audio_path = audio_path.to_path_buf();
         tokio::task::spawn_blocking(move || filter_cue_files_for_audio_sync(cue_files, &audio_path))
-        .await
-        .map_err(|err| anyhow!("blocking task failed to join: {err}"))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))
     }
 }
 

--- a/src/adapters/shnsplit_splitter.rs
+++ b/src/adapters/shnsplit_splitter.rs
@@ -250,8 +250,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        decoder_args, detect_generated_tracks, parse_generated_tracks, snapshot_audio_files_best_effort,
-        ShnsplitCueSplitter,
+        decoder_args, detect_generated_tracks, parse_generated_tracks,
+        snapshot_audio_files_best_effort, ShnsplitCueSplitter,
     };
     use crate::domain::SplitStatus;
 

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -1191,7 +1191,8 @@ mod tests {
         );
 
         repo.upsert_tracked_download_sync(&download).unwrap();
-        repo.mark_download_awaiting_import_sync("download-1").unwrap();
+        repo.mark_download_awaiting_import_sync("download-1")
+            .unwrap();
 
         let conn = Connection::open(&repo.db_path).unwrap();
         conn.execute(
@@ -1203,7 +1204,8 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        repo.mark_download_awaiting_import_sync("download-1").unwrap();
+        repo.mark_download_awaiting_import_sync("download-1")
+            .unwrap();
 
         let stored = repo
             .get_tracked_download_sync("download-1")
@@ -1373,7 +1375,10 @@ mod tests {
             .query_row("PRAGMA busy_timeout", [], |row| row.get::<_, i64>(0))
             .unwrap();
 
-        assert_eq!(busy_timeout_ms, super::SQLITE_BUSY_TIMEOUT.as_millis() as i64);
+        assert_eq!(
+            busy_timeout_ms,
+            super::SQLITE_BUSY_TIMEOUT.as_millis() as i64
+        );
     }
 
     #[test]

--- a/src/application/cleanup_processed_download.rs
+++ b/src/application/cleanup_processed_download.rs
@@ -65,7 +65,8 @@ mod tests {
     use super::cleanup_processed_download;
     use crate::application::ports::{DownloadStore, TrackCleanup};
     use crate::domain::{
-        CueSheet, CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
+        CueSheet, CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack,
+        TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
     };
 
     #[derive(Default)]
@@ -79,7 +80,10 @@ mod tests {
             Ok(Vec::new())
         }
 
-        async fn get_tracked_download(&self, _download_id: &str) -> Result<Option<TrackedDownload>> {
+        async fn get_tracked_download(
+            &self,
+            _download_id: &str,
+        ) -> Result<Option<TrackedDownload>> {
             Ok(None)
         }
 

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -71,6 +71,7 @@ where
     }
 
     if scan.cue_files.is_empty() {
+        eprintln!("Failed processing {}: no cue files found", download.title);
         store
             .mark_download_failed(&download.download_id, Some("no cue files found"))
             .await?;
@@ -104,6 +105,11 @@ where
             Err(err) => {
                 all_cues_complete = false;
                 let message = err.to_string();
+                eprintln!(
+                    "Failed splitting cue for {} at {}: {message}",
+                    download.title,
+                    cue_path.display()
+                );
                 failures.push(format!("{}: {message}", cue_path.display()));
                 store
                     .record_cue_result(&cue_sheet, CueSheetStatus::Failed, Some(&message), &[])

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -106,7 +106,7 @@ where
                 all_cues_complete = false;
                 let message = err.to_string();
                 eprintln!(
-                    "Failed splitting cue for {} at {}: {message}",
+                    "Failed splitting cue for {} at {}: {err:#}",
                     download.title,
                     cue_path.display()
                 );

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -6,8 +6,7 @@ use chrono::prelude::*;
 use crate::application::cleanup_processed_download::cleanup_processed_download;
 use crate::application::monitor_download_queue::classify_downloads;
 use crate::application::ports::{
-    CueInputInspector, CueScanner, CueSplitter,
-    DownloadStore, QueueSource, TrackCleanup,
+    CueInputInspector, CueScanner, CueSplitter, DownloadStore, QueueSource, TrackCleanup,
 };
 use crate::application::process_tracked_download::{
     process_tracked_download, register_failed_imports,


### PR DESCRIPTION
Summary:
- log missing cue file failures before marking downloads failed
- log per-cue shnsplit failures with download title, cue path, and error message
- keep persisted Last Error behavior unchanged

Tests:
- cargo clippy
- cargo test