### PR TITLE
refactor(web): decouple web ui read store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,7 @@ name = "splittarr"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ codegen-units = 1
 
 [dependencies]
 anyhow = "1"
+async-trait = "0.1"
 axum = "0.8"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }

--- a/src/adapters/filesystem_cue_input_inspector.rs
+++ b/src/adapters/filesystem_cue_input_inspector.rs
@@ -34,8 +34,8 @@ impl CueInputInspector for FilesystemCueInputInspector {
         let cue_path = cue_path.to_path_buf();
         let audio_path = audio_path.to_path_buf();
         tokio::task::spawn_blocking(move || cue_references_audio_file_sync(&cue_path, &audio_path))
-        .await
-        .map_err(|err| anyhow!("blocking task failed to join: {err}"))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))
     }
 
     async fn filter_cue_files_for_audio(
@@ -45,8 +45,8 @@ impl CueInputInspector for FilesystemCueInputInspector {
     ) -> Result<Vec<PathBuf>> {
         let audio_path = audio_path.to_path_buf();
         tokio::task::spawn_blocking(move || filter_cue_files_for_audio_sync(cue_files, &audio_path))
-        .await
-        .map_err(|err| anyhow!("blocking task failed to join: {err}"))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))
     }
 }
 

--- a/src/adapters/shnsplit_splitter.rs
+++ b/src/adapters/shnsplit_splitter.rs
@@ -250,8 +250,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        decoder_args, detect_generated_tracks, parse_generated_tracks, snapshot_audio_files_best_effort,
-        ShnsplitCueSplitter,
+        decoder_args, detect_generated_tracks, parse_generated_tracks,
+        snapshot_audio_files_best_effort, ShnsplitCueSplitter,
     };
     use crate::domain::SplitStatus;
 

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
+use async_trait::async_trait;
 use rusqlite::{named_params, params, params_from_iter, Connection, OptionalExtension};
 use uuid::Uuid;
 
@@ -615,6 +616,7 @@ impl DownloadStore for SqliteDownloadStore {
     }
 }
 
+#[async_trait]
 impl DownloadReadStore for SqliteDownloadStore {
     async fn load_download_rows(&self) -> Result<Vec<DownloadHistoryRow>> {
         let store = self.clone();

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use rusqlite::{named_params, params, params_from_iter, Connection, OptionalExtension};
 use uuid::Uuid;
 
-use crate::application::ports::DownloadStore;
+use crate::application::ports::{DownloadHistoryRow, DownloadReadStore, DownloadStore};
 use crate::domain::{
     CueSheet, CueSheetStatus, DownloadLifecycleState, GeneratedTrack, InputFile, InputFileKind,
     RecordedTrack, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
@@ -15,19 +15,6 @@ use crate::domain::{
 #[derive(Debug, Clone)]
 pub struct SqliteDownloadStore {
     db_path: PathBuf,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DownloadRow {
-    pub download_id: String,
-    pub title: String,
-    pub status: String,
-    pub output_path: String,
-    pub tracked_download_state: String,
-    pub lifecycle_state: DownloadLifecycleState,
-    pub updated_at: String,
-    pub completed_at: Option<String>,
-    pub generated_track_count: usize,
 }
 
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
@@ -93,7 +80,7 @@ impl SqliteDownloadStore {
         Ok(downloads)
     }
 
-    fn load_download_rows_sync(&self) -> Result<Vec<DownloadRow>> {
+    fn load_download_rows_sync(&self) -> Result<Vec<DownloadHistoryRow>> {
         let conn = self.connect()?;
         let mut stmt = conn.prepare(
             "SELECT d.download_id, d.title, d.status, d.output_path, d.tracked_download_state,
@@ -114,14 +101,7 @@ impl SqliteDownloadStore {
         Ok(download_rows)
     }
 
-    pub async fn load_download_rows(&self) -> Result<Vec<DownloadRow>> {
-        let store = self.clone();
-        tokio::task::spawn_blocking(move || store.load_download_rows_sync())
-            .await
-            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
-    }
-
-    fn load_download_row_sync(&self, download_id: &str) -> Result<Option<DownloadRow>> {
+    fn load_download_row_sync(&self, download_id: &str) -> Result<Option<DownloadHistoryRow>> {
         let conn = self.connect()?;
         Ok(conn
             .query_row(
@@ -137,14 +117,6 @@ impl SqliteDownloadStore {
                 map_download_history_row,
             )
             .optional()?)
-    }
-
-    pub async fn load_download_row(&self, download_id: &str) -> Result<Option<DownloadRow>> {
-        let store = self.clone();
-        let download_id = download_id.to_owned();
-        tokio::task::spawn_blocking(move || store.load_download_row_sync(&download_id))
-            .await
-            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }
 
     fn get_tracked_download_sync(&self, download_id: &str) -> Result<Option<TrackedDownload>> {
@@ -643,6 +615,31 @@ impl DownloadStore for SqliteDownloadStore {
     }
 }
 
+impl DownloadReadStore for SqliteDownloadStore {
+    async fn load_download_rows(&self) -> Result<Vec<DownloadHistoryRow>> {
+        let store = self.clone();
+        tokio::task::spawn_blocking(move || store.load_download_rows_sync())
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn load_download_row(&self, download_id: &str) -> Result<Option<DownloadHistoryRow>> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        tokio::task::spawn_blocking(move || store.load_download_row_sync(&download_id))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn get_tracked_download(&self, download_id: &str) -> Result<Option<TrackedDownload>> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        tokio::task::spawn_blocking(move || store.get_tracked_download_sync(&download_id))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+}
+
 fn map_download_row(
     conn: &Connection,
     row: &rusqlite::Row<'_>,
@@ -673,8 +670,8 @@ fn map_download_row(
     })
 }
 
-fn map_download_history_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DownloadRow> {
-    Ok(DownloadRow {
+fn map_download_history_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DownloadHistoryRow> {
+    Ok(DownloadHistoryRow {
         download_id: row.get(0)?,
         title: row.get(1)?,
         status: row.get(2)?,
@@ -1191,7 +1188,8 @@ mod tests {
         );
 
         repo.upsert_tracked_download_sync(&download).unwrap();
-        repo.mark_download_awaiting_import_sync("download-1").unwrap();
+        repo.mark_download_awaiting_import_sync("download-1")
+            .unwrap();
 
         let conn = Connection::open(&repo.db_path).unwrap();
         conn.execute(
@@ -1203,7 +1201,8 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        repo.mark_download_awaiting_import_sync("download-1").unwrap();
+        repo.mark_download_awaiting_import_sync("download-1")
+            .unwrap();
 
         let stored = repo
             .get_tracked_download_sync("download-1")
@@ -1373,7 +1372,10 @@ mod tests {
             .query_row("PRAGMA busy_timeout", [], |row| row.get::<_, i64>(0))
             .unwrap();
 
-        assert_eq!(busy_timeout_ms, super::SQLITE_BUSY_TIMEOUT.as_millis() as i64);
+        assert_eq!(
+            busy_timeout_ms,
+            super::SQLITE_BUSY_TIMEOUT.as_millis() as i64
+        );
     }
 
     #[test]

--- a/src/adapters/web.rs
+++ b/src/adapters/web.rs
@@ -526,6 +526,7 @@ pre {
 
 #[cfg(test)]
 mod tests {
+    use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::Request;
     use tower::ServiceExt;
@@ -543,6 +544,7 @@ mod tests {
         detail: Option<TrackedDownload>,
     }
 
+    #[async_trait]
     impl DownloadReadStore for FakeReadStore {
         async fn load_download_rows(&self) -> anyhow::Result<Vec<DownloadHistoryRow>> {
             Ok(self.rows.clone())

--- a/src/adapters/web.rs
+++ b/src/adapters/web.rs
@@ -7,29 +7,31 @@ use axum::{
 };
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 
-use crate::adapters::sqlite_download_store::{DownloadRow, SqliteDownloadStore};
-use crate::application::ports::DownloadStore;
+use crate::application::ports::{DownloadHistoryRow, DownloadReadStore};
 use crate::domain::{
     CueSheet, CueSheetStatus, DownloadLifecycleState, GeneratedTrack, InputFile, InputFileKind,
     TrackCleanupStatus, TrackedDownload,
 };
 
 #[derive(Clone)]
-struct WebState {
-    store: SqliteDownloadStore,
+struct WebState<S> {
+    store: S,
 }
 
-pub fn router(store: SqliteDownloadStore) -> Router {
+pub fn router<S>(store: S) -> Router
+where
+    S: DownloadReadStore + Clone + Send + Sync + 'static,
+{
     Router::new()
-        .route("/", get(index))
+        .route("/", get(index::<S>))
         .route("/healthz", get(healthz))
-        .route("/downloads/{download_id}", get(download_detail))
+        .route("/downloads/{download_id}", get(download_detail::<S>))
         .route(
             "/downloads/{download_id}/content",
-            get(download_detail_content),
+            get(download_detail_content::<S>),
         )
-        .route("/downloads/{download_id}/row", get(download_row_route))
-        .route("/downloads/rows", get(download_rows_route))
+        .route("/downloads/{download_id}/row", get(download_row_route::<S>))
+        .route("/downloads/rows", get(download_rows_route::<S>))
         .with_state(WebState { store })
 }
 
@@ -37,7 +39,10 @@ async fn healthz() -> impl IntoResponse {
     (StatusCode::OK, "ok")
 }
 
-async fn index(State(state): State<WebState>) -> Response {
+async fn index<S>(State(state): State<WebState<S>>) -> Response
+where
+    S: DownloadReadStore,
+{
     match state.store.load_download_rows().await {
         Ok(downloads) => Html(page(
             "Splittarr",
@@ -79,10 +84,13 @@ async fn index(State(state): State<WebState>) -> Response {
     }
 }
 
-async fn download_row_route(
-    State(state): State<WebState>,
+async fn download_row_route<S>(
+    State(state): State<WebState<S>>,
     Path(download_id): Path<String>,
-) -> impl IntoResponse {
+) -> impl IntoResponse
+where
+    S: DownloadReadStore,
+{
     match state.store.load_download_row(&download_id).await {
         Ok(Some(download)) => download_row(&download).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "download not found").into_response(),
@@ -94,7 +102,10 @@ async fn download_row_route(
     }
 }
 
-async fn download_rows_route(State(state): State<WebState>) -> impl IntoResponse {
+async fn download_rows_route<S>(State(state): State<WebState<S>>) -> impl IntoResponse
+where
+    S: DownloadReadStore,
+{
     match state.store.load_download_rows().await {
         Ok(downloads) => download_rows(&downloads).into_response(),
         Err(error) => (
@@ -105,10 +116,13 @@ async fn download_rows_route(State(state): State<WebState>) -> impl IntoResponse
     }
 }
 
-async fn download_detail(
-    State(state): State<WebState>,
+async fn download_detail<S>(
+    State(state): State<WebState<S>>,
     Path(download_id): Path<String>,
-) -> Response {
+) -> Response
+where
+    S: DownloadReadStore,
+{
     match state.store.get_tracked_download(&download_id).await {
         Ok(Some(download)) => Html(page(
             &download.title,
@@ -130,10 +144,13 @@ async fn download_detail(
     }
 }
 
-async fn download_detail_content(
-    State(state): State<WebState>,
+async fn download_detail_content<S>(
+    State(state): State<WebState<S>>,
     Path(download_id): Path<String>,
-) -> impl IntoResponse {
+) -> impl IntoResponse
+where
+    S: DownloadReadStore,
+{
     match state.store.get_tracked_download(&download_id).await {
         Ok(Some(download)) => download_content(&download).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "download not found").into_response(),
@@ -163,7 +180,7 @@ fn page(title: &str, body: Markup) -> String {
     .into_string()
 }
 
-fn download_row(download: &DownloadRow) -> Markup {
+fn download_row(download: &DownloadHistoryRow) -> Markup {
     html! {
         tr id=(format!("download-row-{}", download.download_id)) data-download-id=(&download.download_id) {
             td {
@@ -181,7 +198,7 @@ fn download_row(download: &DownloadRow) -> Markup {
     }
 }
 
-fn download_rows(downloads: &[DownloadRow]) -> Markup {
+fn download_rows(downloads: &[DownloadHistoryRow]) -> Markup {
     html! {
         @for download in downloads {
             (download_row(download))
@@ -514,14 +531,49 @@ mod tests {
     use tower::ServiceExt;
 
     use super::router;
-    use crate::adapters::sqlite_download_store::SqliteDownloadStore;
-    use crate::application::ports::DownloadStore;
-    use crate::domain::{CueSheetStatus, InputFileKind, RecordedTrack, TrackedDownload};
+    use crate::application::ports::{DownloadHistoryRow, DownloadReadStore};
+    use crate::domain::{
+        CueSheet, CueSheetStatus, DownloadLifecycleState, GeneratedTrack, InputFile, InputFileKind,
+        TrackCleanupStatus, TrackedDownload,
+    };
+
+    #[derive(Clone, Default)]
+    struct FakeReadStore {
+        rows: Vec<DownloadHistoryRow>,
+        detail: Option<TrackedDownload>,
+    }
+
+    impl DownloadReadStore for FakeReadStore {
+        async fn load_download_rows(&self) -> anyhow::Result<Vec<DownloadHistoryRow>> {
+            Ok(self.rows.clone())
+        }
+
+        async fn load_download_row(
+            &self,
+            download_id: &str,
+        ) -> anyhow::Result<Option<DownloadHistoryRow>> {
+            Ok(self
+                .rows
+                .iter()
+                .find(|row| row.download_id == download_id)
+                .cloned())
+        }
+
+        async fn get_tracked_download(
+            &self,
+            download_id: &str,
+        ) -> anyhow::Result<Option<TrackedDownload>> {
+            Ok(self
+                .detail
+                .as_ref()
+                .filter(|download| download.download_id == download_id)
+                .cloned())
+        }
+    }
 
     #[tokio::test]
-    async fn index_renders_empty_state() {
-        let tmp = tempfile::tempdir().unwrap();
-        let app = router(SqliteDownloadStore::open(tmp.path()).unwrap());
+    async fn index_renders_empty_state_with_fake_read_store() {
+        let app = router(FakeReadStore::default());
 
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
@@ -536,45 +588,45 @@ mod tests {
 
     #[tokio::test]
     async fn detail_renders_recorded_files() {
-        let tmp = tempfile::tempdir().unwrap();
-        let store = SqliteDownloadStore::open(tmp.path()).unwrap();
-        let download = TrackedDownload::pending(
+        let mut download = TrackedDownload::pending(
             "abc".into(),
             "Album".into(),
             "completed".into(),
             "/downloads/album".into(),
             "importFailed".into(),
         );
-        store.upsert_tracked_download(&download).await.unwrap();
-        store.mark_download_processing("abc").await.unwrap();
-        let cue = store
-            .get_or_create_cue_sheet("abc", std::path::Path::new("/downloads/album/album.cue"))
-            .await
-            .unwrap();
-        store
-            .record_input_file(
-                "abc",
-                Some(&cue.id),
-                std::path::Path::new("/downloads/album/album.cue"),
-                InputFileKind::Cue,
-                Some(12),
-            )
-            .await
-            .unwrap();
-        store
-            .record_cue_result(
-                &cue,
-                CueSheetStatus::Split,
-                None,
-                &[RecordedTrack {
-                    path: "/downloads/album/01.flac".into(),
-                    size_bytes: Some(64),
-                }],
-            )
-            .await
-            .unwrap();
+        download.input_files = vec![InputFile {
+            id: "input-1".into(),
+            download_id: "abc".into(),
+            cue_sheet_id: Some("cue-1".into()),
+            path: "/downloads/album/album.cue".into(),
+            kind: InputFileKind::Cue,
+            size_bytes: Some(12),
+            captured_at: "2026-06-12 12:00:00".into(),
+        }];
+        download.cue_sheets = vec![CueSheet {
+            id: "cue-1".into(),
+            download_id: "abc".into(),
+            path: "/downloads/album/album.cue".into(),
+            status: CueSheetStatus::Split,
+            message: None,
+            updated_at: "2026-06-12 12:00:00".into(),
+            tracks: vec![GeneratedTrack {
+                id: "track-1".into(),
+                cue_sheet_id: "cue-1".into(),
+                download_id: "abc".into(),
+                path: "/downloads/album/01.flac".into(),
+                size_bytes: Some(64),
+                cleanup_status: TrackCleanupStatus::Pending,
+                cleanup_message: None,
+                deleted_at: None,
+            }],
+        }];
 
-        let app = router(store);
+        let app = router(FakeReadStore {
+            detail: Some(download),
+            ..FakeReadStore::default()
+        });
         let response = app
             .oneshot(
                 Request::builder()
@@ -595,18 +647,20 @@ mod tests {
 
     #[tokio::test]
     async fn rows_endpoint_renders_all_rows_in_one_response() {
-        let tmp = tempfile::tempdir().unwrap();
-        let store = SqliteDownloadStore::open(tmp.path()).unwrap();
-        let download = TrackedDownload::pending(
-            "abc".into(),
-            "Album".into(),
-            "completed".into(),
-            "/downloads/album".into(),
-            "importFailed".into(),
-        );
-        store.upsert_tracked_download(&download).await.unwrap();
-
-        let app = router(store);
+        let app = router(FakeReadStore {
+            rows: vec![DownloadHistoryRow {
+                download_id: "abc".into(),
+                title: "Album".into(),
+                status: "completed".into(),
+                output_path: "/downloads/album".into(),
+                tracked_download_state: "importFailed".into(),
+                lifecycle_state: DownloadLifecycleState::Detected,
+                updated_at: "2026-06-12 12:00:00".into(),
+                completed_at: None,
+                generated_track_count: 0,
+            }],
+            detail: None,
+        });
         let response = app
             .oneshot(
                 Request::builder()

--- a/src/application/cleanup_processed_download.rs
+++ b/src/application/cleanup_processed_download.rs
@@ -65,7 +65,8 @@ mod tests {
     use super::cleanup_processed_download;
     use crate::application::ports::{DownloadStore, TrackCleanup};
     use crate::domain::{
-        CueSheet, CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
+        CueSheet, CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack,
+        TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
     };
 
     #[derive(Default)]
@@ -79,7 +80,10 @@ mod tests {
             Ok(Vec::new())
         }
 
-        async fn get_tracked_download(&self, _download_id: &str) -> Result<Option<TrackedDownload>> {
+        async fn get_tracked_download(
+            &self,
+            _download_id: &str,
+        ) -> Result<Option<TrackedDownload>> {
             Ok(None)
         }
 

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -1,14 +1,41 @@
+use std::future::Future;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
 use crate::domain::{
-    CueSheet, CueSheetStatus, DiscoveredCueSheets, InputFileKind, QueueSnapshot, RecordedTrack,
-    SplitOutcome, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
+    CueSheet, CueSheetStatus, DiscoveredCueSheets, DownloadLifecycleState, InputFileKind,
+    QueueSnapshot, RecordedTrack, SplitOutcome, TrackCleanupOutcome, TrackCleanupStatus,
+    TrackedDownload,
 };
 
 pub trait QueueSource {
     async fn queue_snapshot(&self) -> Result<QueueSnapshot>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DownloadHistoryRow {
+    pub download_id: String,
+    pub title: String,
+    pub status: String,
+    pub output_path: String,
+    pub tracked_download_state: String,
+    pub lifecycle_state: DownloadLifecycleState,
+    pub updated_at: String,
+    pub completed_at: Option<String>,
+    pub generated_track_count: usize,
+}
+
+pub trait DownloadReadStore {
+    fn load_download_rows(&self) -> impl Future<Output = Result<Vec<DownloadHistoryRow>>> + Send;
+    fn load_download_row(
+        &self,
+        download_id: &str,
+    ) -> impl Future<Output = Result<Option<DownloadHistoryRow>>> + Send;
+    fn get_tracked_download(
+        &self,
+        download_id: &str,
+    ) -> impl Future<Output = Result<Option<TrackedDownload>>> + Send;
 }
 
 pub trait DownloadStore {

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -1,7 +1,7 @@
-use std::future::Future;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use async_trait::async_trait;
 
 use crate::domain::{
     CueSheet, CueSheetStatus, DiscoveredCueSheets, DownloadLifecycleState, InputFileKind,
@@ -26,16 +26,11 @@ pub struct DownloadHistoryRow {
     pub generated_track_count: usize,
 }
 
+#[async_trait]
 pub trait DownloadReadStore {
-    fn load_download_rows(&self) -> impl Future<Output = Result<Vec<DownloadHistoryRow>>> + Send;
-    fn load_download_row(
-        &self,
-        download_id: &str,
-    ) -> impl Future<Output = Result<Option<DownloadHistoryRow>>> + Send;
-    fn get_tracked_download(
-        &self,
-        download_id: &str,
-    ) -> impl Future<Output = Result<Option<TrackedDownload>>> + Send;
+    async fn load_download_rows(&self) -> Result<Vec<DownloadHistoryRow>>;
+    async fn load_download_row(&self, download_id: &str) -> Result<Option<DownloadHistoryRow>>;
+    async fn get_tracked_download(&self, download_id: &str) -> Result<Option<TrackedDownload>>;
 }
 
 pub trait DownloadStore {

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -6,8 +6,7 @@ use chrono::prelude::*;
 use crate::application::cleanup_processed_download::cleanup_processed_download;
 use crate::application::monitor_download_queue::classify_downloads;
 use crate::application::ports::{
-    CueInputInspector, CueScanner, CueSplitter,
-    DownloadStore, QueueSource, TrackCleanup,
+    CueInputInspector, CueScanner, CueSplitter, DownloadStore, QueueSource, TrackCleanup,
 };
 use crate::application::process_tracked_download::{
     process_tracked_download, register_failed_imports,


### PR DESCRIPTION
## Summary
- add an application read port and history row model for web UI queries
- implement the read port for the SQLite store
- make the web router generic over the read port and switch web tests to a fake read store

Closes #17

## Validation
- cargo clippy
- cargo test