### PR TITLE
feat(lidarr): trigger manual import after splitting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1578,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "config",
@@ -1572,6 +1590,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha1",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ codegen-units = 1
 anyhow = "1"
 async-trait = "0.1"
 axum = "0.8"
+base64 = "0.22"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 config = "0.13.1"
@@ -34,6 +35,7 @@ reqwest = { version = "0.11.10", default-features = false, features = ["rustls-t
 rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.85"
+sha1 = "0.10"
 thiserror = "1"
 tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread", "time", "net", "io-util"] }
 uuid = { version = "1.1.2", features=["v4"] }

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ services:
       SPLITTARR_DATA_DIR: /config
       SPLITTARR_CHECK_FREQUENCY_SECONDS: 60
       SPLITTARR_SERVER__BIND_ADDRESS: 127.0.0.1:9899
+      SPLITTARR_LOGGING__DOWNLOAD_LOG_ENABLED: "true"
+      SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED: "false"
+      SPLITTARR_GNUDB__DISC_LOOKUP_ENABLED: "false"
+      SPLITTARR_GNUDB__SERVER: gnudb.gnudb.org
+      SPLITTARR_GNUDB__USER_EMAIL: ""
       SPLITTARR_CUE__STRICT: "false"
       SPLITTARR_SHNSPLIT__PATH: shnsplit
       SPLITTARR_SHNSPLIT__OVERWRITE: "true"
@@ -132,10 +137,26 @@ check_frequency_seconds = 60
 [server]
 bind_address = "127.0.0.1:9899"
 
+[logging]
+download_log_enabled = true
+
+[gnudb]
+disc_lookup_enabled = false
+# Use "gnudb.gnudb.org", your signup host like "7vrcg0sd.gnudb.org",
+# or just the unique signup code like "7vrcg0sd".
+server = "gnudb.gnudb.org"
+user_email = ""
+
+[musicbrainz]
+disc_lookup_enabled = true
+base_url = "https://musicbrainz.org"
+trust_disc_lookup = false
+add_missing_release_group_enabled = false
+
 [lidarr]
 url = "http://lidarr:8686"
 api_key = "your-lidarr-api-key"
-manual_import_enabled = false
+manual_import_enabled = true
 
 [cue]
 strict = false
@@ -165,7 +186,15 @@ Nested configuration keys use a double underscore.
 ```bash
 export SPLITTARR_LIDARR__URL=http://lidarr:8686
 export SPLITTARR_LIDARR__API_KEY=your-lidarr-api-key
-export SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED=false
+export SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED=true
+export SPLITTARR_LOGGING__DOWNLOAD_LOG_ENABLED=true
+export SPLITTARR_GNUDB__DISC_LOOKUP_ENABLED=false
+export SPLITTARR_GNUDB__SERVER=gnudb.gnudb.org
+export SPLITTARR_GNUDB__USER_EMAIL=user@example.com
+export SPLITTARR_MUSICBRAINZ__DISC_LOOKUP_ENABLED=true
+export SPLITTARR_MUSICBRAINZ__BASE_URL=https://musicbrainz.org
+export SPLITTARR_MUSICBRAINZ__TRUST_DISC_LOOKUP=false
+export SPLITTARR_MUSICBRAINZ__ADD_MISSING_RELEASE_GROUP_ENABLED=false
 export SPLITTARR_CHECK_FREQUENCY_SECONDS=60
 export SPLITTARR_SERVER__BIND_ADDRESS=127.0.0.1:9899
 export SPLITTARR_SHNSPLIT__FORMAT="%p - %a - %n - %t"
@@ -180,13 +209,29 @@ splittarr
 | `data_dir`                | `SPLITTARR_DATA_DIR`                | platform data dir, `/config` in Docker | Directory used for Splittarr's SQLite database.            |
 | `check_frequency_seconds` | `SPLITTARR_CHECK_FREQUENCY_SECONDS` | `60`                                   | How often Splittarr polls Lidarr's queue.                  |
 | `server.bind_address`     | `SPLITTARR_SERVER__BIND_ADDRESS`    | `127.0.0.1:9899`                       | Address for the built-in web UI and health endpoint.       |
+| `logging.download_log_enabled` | `SPLITTARR_LOGGING__DOWNLOAD_LOG_ENABLED` | `true` | Whether Splittarr writes `splittarr.log` into processed download folders. |
+| `gnudb.disc_lookup_enabled` | `SPLITTARR_GNUDB__DISC_LOOKUP_ENABLED` | `false` | Whether Splittarr may use CUE `REM DISCID` values to ask GnuDB for release-selection hints. |
+| `gnudb.server`            | `SPLITTARR_GNUDB__SERVER`           | `gnudb.gnudb.org`                       | GnuDB hostname or signup code, for example `7vrcg0sd.gnudb.org` or `7vrcg0sd`. |
+| `gnudb.user_email`        | `SPLITTARR_GNUDB__USER_EMAIL`       | empty                                  | Email used in GnuDB's required `hello` field; required when GnuDB lookup is enabled. |
+| `musicbrainz.disc_lookup_enabled` | `SPLITTARR_MUSICBRAINZ__DISC_LOOKUP_ENABLED` | `true` | Whether Splittarr may calculate a MusicBrainz Disc ID from CUE/audio lengths and query MusicBrainz before GnuDB fallback. |
+| `musicbrainz.base_url` | `SPLITTARR_MUSICBRAINZ__BASE_URL` | `https://musicbrainz.org` | MusicBrainz base URL. |
+| `musicbrainz.trust_disc_lookup` | `SPLITTARR_MUSICBRAINZ__TRUST_DISC_LOOKUP` | `false` | Whether a successful MusicBrainz Disc ID match may override the initial CUE-title album match and choose another compatible Lidarr album/release for the same artist. |
+| `musicbrainz.add_missing_release_group_enabled` | `SPLITTARR_MUSICBRAINZ__ADD_MISSING_RELEASE_GROUP_ENABLED` | `false` | Whether Splittarr may add a missing Lidarr album for the same artist from a single MusicBrainz release-group Disc ID result before manual-import fallback gives up. |
 | `lidarr.url`              | `SPLITTARR_LIDARR__URL`             | required                               | Base URL for Lidarr, for example `http://lidarr:8686`.     |
 | `lidarr.api_key`          | `SPLITTARR_LIDARR__API_KEY`         | required                               | Lidarr API key.                                            |
-| `lidarr.manual_import_enabled` | `SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED` | `false` | Whether Splittarr should ask Lidarr to manually import generated tracks after splitting. |
+| `lidarr.manual_import_enabled` | `SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED` | `true` | Whether Splittarr should ask Lidarr to manually import generated tracks after splitting. |
 | `cue.strict`              | `SPLITTARR_CUE__STRICT`             | `false`                                | Whether CUE parsing should run in strict mode.             |
 | `shnsplit.path`           | `SPLITTARR_SHNSPLIT__PATH`          | `shnsplit`                             | Path to the `shnsplit` executable.                         |
 | `shnsplit.overwrite`      | `SPLITTARR_SHNSPLIT__OVERWRITE`     | `true`                                 | Whether `shnsplit` should overwrite existing output files. |
 | `shnsplit.format`         | `SPLITTARR_SHNSPLIT__FORMAT`        | `%p - %a - %n - %t`                    | Output filename format passed to `shnsplit -t`.            |
+
+MusicBrainz lookup is enabled by default. Splittarr reads referenced WAV/FLAC lengths, calculates a true MusicBrainz Disc ID, asks MusicBrainz `/ws/2/discid`, and selects a Lidarr release when MusicBrainz and Lidarr agree on a compatible release. If MusicBrainz is disabled or inconclusive, Splittarr falls back to GnuDB.
+
+`musicbrainz.trust_disc_lookup` is a stronger, separate opt-in. Leave it `false` if Splittarr should only use MusicBrainz as a release-ID tie breaker inside the album Lidarr already matched from the CUE/download title. Set it to `true` if you want a MusicBrainz Disc ID match to be trusted enough to search the same Lidarr artist for another album whose title matches the MusicBrainz release or release-group title. Even when enabled, Splittarr still requires compatible track counts and still runs the final generated-track-to-Lidarr-track mapping before starting manual import.
+
+`musicbrainz.add_missing_release_group_enabled` is disabled by default because it can change your Lidarr library. When enabled, if MusicBrainz Disc ID lookup returns releases that all belong to one release group and Splittarr cannot find a compatible Lidarr release, Splittarr asks Lidarr for `lidarr:<release-group-mbid>`, adds that album for the same artist as unmonitored, does not trigger a Lidarr search/download, and then tries the manual import again against the newly added album.
+
+GnuDB lookup only uses 8-character CDDB/freeDB-style `REM DISCID` values from CUE files. If GnuDB registration says to change `gnudb.gnudb.org` to `<code>.gnudb.org`, put either that hostname or just `<code>` in `gnudb.server`; Splittarr builds the required plain HTTP CDDB endpoint internally.
 
 ## Output filename format
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ bind_address = "127.0.0.1:9899"
 [lidarr]
 url = "http://lidarr:8686"
 api_key = "your-lidarr-api-key"
+manual_import_enabled = false
 
 [cue]
 strict = false
@@ -164,6 +165,7 @@ Nested configuration keys use a double underscore.
 ```bash
 export SPLITTARR_LIDARR__URL=http://lidarr:8686
 export SPLITTARR_LIDARR__API_KEY=your-lidarr-api-key
+export SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED=false
 export SPLITTARR_CHECK_FREQUENCY_SECONDS=60
 export SPLITTARR_SERVER__BIND_ADDRESS=127.0.0.1:9899
 export SPLITTARR_SHNSPLIT__FORMAT="%p - %a - %n - %t"
@@ -180,6 +182,7 @@ splittarr
 | `server.bind_address`     | `SPLITTARR_SERVER__BIND_ADDRESS`    | `127.0.0.1:9899`                       | Address for the built-in web UI and health endpoint.       |
 | `lidarr.url`              | `SPLITTARR_LIDARR__URL`             | required                               | Base URL for Lidarr, for example `http://lidarr:8686`.     |
 | `lidarr.api_key`          | `SPLITTARR_LIDARR__API_KEY`         | required                               | Lidarr API key.                                            |
+| `lidarr.manual_import_enabled` | `SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED` | `false` | Whether Splittarr should ask Lidarr to manually import generated tracks after splitting. |
 | `cue.strict`              | `SPLITTARR_CUE__STRICT`             | `false`                                | Whether CUE parsing should run in strict mode.             |
 | `shnsplit.path`           | `SPLITTARR_SHNSPLIT__PATH`          | `shnsplit`                             | Path to the `shnsplit` executable.                         |
 | `shnsplit.overwrite`      | `SPLITTARR_SHNSPLIT__OVERWRITE`     | `true`                                 | Whether `shnsplit` should overwrite existing output files. |

--- a/config.toml.example
+++ b/config.toml.example
@@ -4,12 +4,28 @@ check_frequency_seconds = 60
 [server]
 bind_address = "127.0.0.1:9899"
 
+[logging]
+download_log_enabled = true
+
+[gnudb]
+disc_lookup_enabled = false
+# Use "gnudb.gnudb.org", your signup host like "4ckgj7jx.gnudb.org",
+# or just the unique signup code like "4ckgj7jx".
+server = "gnudb.gnudb.org"
+user_email = ""
+
+[musicbrainz]
+disc_lookup_enabled = true
+base_url = "https://musicbrainz.org"
+trust_disc_lookup = false
+add_missing_release_group_enabled = false
+
 [lidarr]
 url = "https://lidarr.example.com"
 api_key = "a3bb47a4968223c7568b06d4a2e9cf95"
 queue_page_size = 100
 queue_max_pages = 100
-manual_import_enabled = false
+manual_import_enabled = true
 
 [cue]
 strict = false

--- a/config.toml.example
+++ b/config.toml.example
@@ -9,6 +9,7 @@ url = "https://lidarr.example.com"
 api_key = "a3bb47a4968223c7568b06d4a2e9cf95"
 queue_page_size = 100
 queue_max_pages = 100
+manual_import_enabled = false
 
 [cue]
 strict = false

--- a/src/adapters/filesystem_download_log.rs
+++ b/src/adapters/filesystem_download_log.rs
@@ -1,0 +1,139 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+
+use crate::application::ports::DownloadLog;
+use crate::domain::TrackedDownload;
+
+#[derive(Debug, Clone)]
+pub struct FilesystemDownloadLog {
+    enabled: bool,
+}
+
+impl FilesystemDownloadLog {
+    pub fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+}
+
+impl DownloadLog for FilesystemDownloadLog {
+    async fn write_download_log(&self, download: &TrackedDownload, content: &str) -> Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        let path = download_log_path(download);
+        let display_path = path.display().to_string();
+        let content = content.to_owned();
+        tokio::task::spawn_blocking(move || fs::write(&path, content))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+            .map_err(|err| anyhow!("failed writing {display_path}: {err}"))
+    }
+
+    async fn delete_download_log(&self, download: &TrackedDownload) -> Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        let path = download_log_path(download);
+        tokio::task::spawn_blocking(move || match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(anyhow!("failed deleting {}: {err}", path.display())),
+        })
+        .await
+        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+}
+
+fn download_log_path(download: &TrackedDownload) -> PathBuf {
+    download_root_path(&PathBuf::from(&download.output_path)).join("splittarr.log")
+}
+
+fn download_root_path(output_path: &Path) -> PathBuf {
+    if output_path.is_file() {
+        return output_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| output_path.to_path_buf());
+    }
+
+    output_path.to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::{download_log_path, FilesystemDownloadLog};
+    use crate::application::ports::DownloadLog;
+    use crate::domain::TrackedDownload;
+
+    #[tokio::test]
+    async fn writes_log_to_download_directory() {
+        let tmp = tempdir().unwrap();
+        let download = download(tmp.path().to_string_lossy().to_string());
+        let logger = FilesystemDownloadLog::new(true);
+
+        logger.write_download_log(&download, "hello").await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("splittarr.log")).unwrap(),
+            "hello"
+        );
+    }
+
+    #[tokio::test]
+    async fn writes_log_to_parent_when_output_path_is_a_file() {
+        let tmp = tempdir().unwrap();
+        let audio_path = tmp.path().join("album.flac");
+        fs::write(&audio_path, b"audio").unwrap();
+        let download = download(audio_path.to_string_lossy().to_string());
+        let logger = FilesystemDownloadLog::new(true);
+
+        logger.write_download_log(&download, "hello").await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(tmp.path().join("splittarr.log")).unwrap(),
+            "hello"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_logger_does_not_write() {
+        let tmp = tempdir().unwrap();
+        let download = download(tmp.path().to_string_lossy().to_string());
+        let logger = FilesystemDownloadLog::new(false);
+
+        logger.write_download_log(&download, "hello").await.unwrap();
+
+        assert!(!tmp.path().join("splittarr.log").exists());
+    }
+
+    #[tokio::test]
+    async fn deletes_existing_log_and_ignores_missing_log() {
+        let tmp = tempdir().unwrap();
+        let download = download(tmp.path().to_string_lossy().to_string());
+        fs::write(download_log_path(&download), "hello").unwrap();
+        let logger = FilesystemDownloadLog::new(true);
+
+        logger.delete_download_log(&download).await.unwrap();
+        logger.delete_download_log(&download).await.unwrap();
+
+        assert!(!tmp.path().join("splittarr.log").exists());
+    }
+
+    fn download(output_path: String) -> TrackedDownload {
+        TrackedDownload::pending(
+            "download-1".into(),
+            "Album".into(),
+            "completed".into(),
+            output_path,
+            "importFailed".into(),
+        )
+    }
+}

--- a/src/adapters/gnudb_api.rs
+++ b/src/adapters/gnudb_api.rs
@@ -1,0 +1,569 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use reqwest::Client;
+
+use crate::application::ports::{
+    DiscReleaseCandidate, DiscReleaseLookup, DiscReleaseLookupRequest, DiscReleaseLookupResult,
+};
+use crate::bootstrap::settings::GnudbSettings;
+
+#[derive(Debug, Clone)]
+pub struct GnudbDiscReleaseLookup {
+    enabled: bool,
+    server: String,
+    user_email: String,
+    client: Client,
+}
+
+impl GnudbDiscReleaseLookup {
+    pub fn new(settings: &GnudbSettings) -> Self {
+        Self {
+            enabled: settings.disc_lookup_enabled,
+            server: settings.server.clone(),
+            user_email: settings.user_email.clone(),
+            client: Client::new(),
+        }
+    }
+
+    async fn request(&self, command: String) -> Result<String> {
+        let response = self
+            .client
+            .get(self.endpoint_url())
+            .query(&[
+                ("cmd", command.as_str()),
+                ("hello", self.hello().as_str()),
+                ("proto", "6"),
+            ])
+            .send()
+            .await
+            .map_err(|err| anyhow!("failed requesting GnuDB: {err}"))?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|err| anyhow!("failed reading GnuDB response: {err}"))?;
+
+        if !status.is_success() {
+            return Err(anyhow!("GnuDB returned HTTP {status}: {body}"));
+        }
+
+        Ok(body)
+    }
+
+    fn hello(&self) -> String {
+        let (name, host) = self
+            .user_email
+            .split_once('@')
+            .unwrap_or(("splittarr", "localhost"));
+        format!("{}+{}+splittarr+{}", name, host, env!("CARGO_PKG_VERSION"))
+    }
+
+    fn endpoint_url(&self) -> String {
+        if self.server.starts_with("http://") || self.server.starts_with("https://") {
+            return self.server.clone();
+        }
+        format!("http://{}/~cddb/cddb.cgi", self.server)
+    }
+}
+
+#[async_trait]
+impl DiscReleaseLookup for GnudbDiscReleaseLookup {
+    async fn lookup_disc_release(
+        &self,
+        request: DiscReleaseLookupRequest,
+    ) -> Result<DiscReleaseLookupResult> {
+        if !self.enabled {
+            return Ok(DiscReleaseLookupResult::Disabled {
+                diagnostic: "GnuDB lookup: disabled\n".into(),
+            });
+        }
+
+        let mut diagnostic = String::new();
+        diagnostic.push_str("GnuDB lookup: enabled\n");
+        diagnostic.push_str(&format!("GnuDB requested DISCID: {}\n", request.disc_id));
+        diagnostic.push_str(&format!(
+            "GnuDB search inputs: artist={} album={} year={} tracks={}\n",
+            request.artist.as_deref().unwrap_or("-"),
+            request.album_title.as_deref().unwrap_or("-"),
+            request
+                .year
+                .map(|year| year.to_string())
+                .unwrap_or_else(|| "-".into()),
+            request.track_count
+        ));
+
+        let Some(artist) = request
+            .artist
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        else {
+            diagnostic.push_str("GnuDB lookup: skipped because artist hint is missing\n");
+            return Ok(DiscReleaseLookupResult::NotFound { diagnostic });
+        };
+        let Some(album) = request
+            .album_title
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        else {
+            diagnostic.push_str("GnuDB lookup: skipped because album hint is missing\n");
+            return Ok(DiscReleaseLookupResult::NotFound { diagnostic });
+        };
+
+        let search_command = format!(
+            "search artist {artist} album {album} tracks {}",
+            request.track_count
+        );
+        let search_body = match self.request(search_command).await {
+            Ok(body) => body,
+            Err(err) => {
+                diagnostic.push_str(&format!("GnuDB lookup failed: {err}\n"));
+                return Ok(DiscReleaseLookupResult::NotFound { diagnostic });
+            }
+        };
+        let search_candidates = parse_search_response(&search_body);
+        diagnostic.push_str(&format!(
+            "GnuDB search candidates: {}\n",
+            search_candidates.len()
+        ));
+
+        if search_candidates.is_empty() {
+            diagnostic.push_str("GnuDB lookup: no search candidates\n");
+            return Ok(DiscReleaseLookupResult::NotFound { diagnostic });
+        }
+
+        let mut accepted = Vec::new();
+        for search_candidate in search_candidates {
+            diagnostic.push_str(&format!(
+                "GnuDB read candidate: category={} id={} title={}\n",
+                search_candidate.category, search_candidate.entry_id, search_candidate.title
+            ));
+            let read_body = match self
+                .request(format!(
+                    "cddb read {} {}",
+                    search_candidate.category, search_candidate.entry_id
+                ))
+                .await
+            {
+                Ok(body) => body,
+                Err(err) => {
+                    diagnostic.push_str(&format!("  read failed: {err}\n"));
+                    continue;
+                }
+            };
+            let Some(candidate) = parse_read_response(
+                &search_candidate.category,
+                &search_candidate.entry_id,
+                &read_body,
+            ) else {
+                diagnostic.push_str("  read parse: no xmcd entry\n");
+                continue;
+            };
+            append_candidate_diagnostic(&mut diagnostic, &candidate);
+            if !candidate.disc_id.eq_ignore_ascii_case(&request.disc_id) {
+                diagnostic.push_str("  rejected: DISCID mismatch\n");
+                continue;
+            }
+            if request.year.is_some() && request.year != candidate.year {
+                diagnostic.push_str("  rejected: year mismatch\n");
+                continue;
+            }
+            if candidate.track_titles.len() != request.track_count {
+                diagnostic.push_str("  rejected: track count mismatch\n");
+                continue;
+            }
+            if !gnudb_track_titles_match(&request.track_titles_by_number, &candidate.track_titles) {
+                diagnostic.push_str("  rejected: track titles did not align\n");
+                continue;
+            }
+            accepted.push(candidate);
+        }
+
+        diagnostic.push_str(&format!("GnuDB accepted candidates: {}\n", accepted.len()));
+        if accepted.is_empty() {
+            Ok(DiscReleaseLookupResult::NotFound { diagnostic })
+        } else {
+            Ok(DiscReleaseLookupResult::Found {
+                candidates: accepted,
+                diagnostic,
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GnudbSearchCandidate {
+    category: String,
+    entry_id: String,
+    title: String,
+}
+
+fn parse_search_response(body: &str) -> Vec<GnudbSearchCandidate> {
+    let mut lines = body.lines().map(str::trim).filter(|line| !line.is_empty());
+    let Some(first) = lines.next() else {
+        return Vec::new();
+    };
+    let code = first.get(..3).unwrap_or_default();
+    match code {
+        "200" => parse_search_candidate_line(first.get(4..).unwrap_or_default())
+            .into_iter()
+            .collect(),
+        "210" | "211" => lines
+            .take_while(|line| *line != ".")
+            .filter_map(parse_search_candidate_line)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn parse_search_candidate_line(line: &str) -> Option<GnudbSearchCandidate> {
+    let mut parts = line.splitn(3, char::is_whitespace);
+    let category = parts.next()?.trim();
+    let entry_id = parts.next()?.trim();
+    let title = parts.next().unwrap_or_default().trim();
+    if category.is_empty() || entry_id.is_empty() {
+        return None;
+    }
+    Some(GnudbSearchCandidate {
+        category: category.to_owned(),
+        entry_id: entry_id.to_owned(),
+        title: title.to_owned(),
+    })
+}
+
+fn parse_read_response(category: &str, entry_id: &str, body: &str) -> Option<DiscReleaseCandidate> {
+    let mut fields = Vec::new();
+    let mut art_ids = Vec::new();
+    for line in body.lines().map(str::trim_end) {
+        if line == "." {
+            break;
+        }
+        if let Some(art_id) = line.strip_prefix("# Artid:") {
+            let art_id = art_id.trim();
+            if !art_id.is_empty() {
+                art_ids.push(art_id.to_owned());
+            }
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        fields.push((key.trim().to_owned(), value.trim().to_owned()));
+    }
+
+    let disc_id = field_value(&fields, "DISCID")?;
+    let (artist, title) = field_value(&fields, "DTITLE")
+        .map(split_dtitle)
+        .unwrap_or((None, None));
+    let year = field_value(&fields, "DYEAR").and_then(first_year);
+    let mut tracks = fields
+        .iter()
+        .filter_map(|(key, value)| {
+            let index = key.strip_prefix("TTITLE")?.parse::<usize>().ok()?;
+            Some((index, value.clone()))
+        })
+        .collect::<Vec<_>>();
+    tracks.sort_by_key(|(index, _)| *index);
+
+    Some(DiscReleaseCandidate {
+        category: category.to_owned(),
+        entry_id: entry_id.to_owned(),
+        disc_id: disc_id.to_owned(),
+        artist,
+        title,
+        year,
+        track_titles: tracks.into_iter().map(|(_, title)| title).collect(),
+        art_ids,
+    })
+}
+
+fn field_value<'a>(fields: &'a [(String, String)], key: &str) -> Option<&'a str> {
+    fields
+        .iter()
+        .find(|(field_key, _)| field_key.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.as_str())
+        .filter(|value| !value.is_empty())
+}
+
+fn split_dtitle(value: &str) -> (Option<String>, Option<String>) {
+    let Some((artist, title)) = value.split_once(" / ") else {
+        return (
+            None,
+            Some(value.trim().to_owned()).filter(|value| !value.is_empty()),
+        );
+    };
+    (
+        Some(artist.trim().to_owned()).filter(|value| !value.is_empty()),
+        Some(title.trim().to_owned()).filter(|value| !value.is_empty()),
+    )
+}
+
+fn first_year(value: &str) -> Option<i32> {
+    value
+        .as_bytes()
+        .windows(4)
+        .filter_map(|window| std::str::from_utf8(window).ok())
+        .find_map(|candidate| {
+            let year = candidate.parse::<i32>().ok()?;
+            (1900..=2100).contains(&year).then_some(year)
+        })
+}
+
+fn gnudb_track_titles_match(expected: &[(i64, String)], actual: &[String]) -> bool {
+    if expected.is_empty() {
+        return true;
+    }
+    expected.iter().all(|(number, title)| {
+        let Some(actual_title) = usize::try_from(*number)
+            .ok()
+            .and_then(|number| number.checked_sub(1))
+            .and_then(|index| actual.get(index))
+        else {
+            return false;
+        };
+        titles_match(title, actual_title)
+    })
+}
+
+fn titles_match(left: &str, right: &str) -> bool {
+    let left = normalize_text(left);
+    let right = normalize_text(right);
+    !left.is_empty() && (left == right || left.contains(&right) || right.contains(&left))
+}
+
+fn normalize_text(value: &str) -> String {
+    let mut normalized = String::with_capacity(value.len());
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_alphanumeric() {
+            normalized.push(ch);
+        } else {
+            normalized.push(' ');
+        }
+    }
+    normalized.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn append_candidate_diagnostic(diagnostic: &mut String, candidate: &DiscReleaseCandidate) {
+    diagnostic.push_str(&format!(
+        "  read: disc_id={} artist={} title={} year={} tracks={} art_ids=[{}]\n",
+        candidate.disc_id,
+        candidate.artist.as_deref().unwrap_or("-"),
+        candidate.title.as_deref().unwrap_or("-"),
+        candidate
+            .year
+            .map(|year| year.to_string())
+            .unwrap_or_else(|| "-".into()),
+        candidate.track_titles.len(),
+        candidate.art_ids.join(", ")
+    ));
+    for (index, title) in candidate.track_titles.iter().enumerate() {
+        diagnostic.push_str(&format!("    TTITLE{}={}\n", index, title));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use super::{parse_read_response, parse_search_response, GnudbDiscReleaseLookup};
+    use crate::application::ports::{DiscReleaseLookup, DiscReleaseLookupResult};
+    use crate::bootstrap::settings::GnudbSettings;
+
+    #[test]
+    fn parses_search_candidates() {
+        let candidates = parse_search_response(
+            "210 Found exact matches, list follows\nrock 9f0c2a0d Artist / Album\nmisc c60c9d10 Other / Album\n.\n",
+        );
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].category, "rock");
+        assert_eq!(candidates[0].entry_id, "9f0c2a0d");
+        assert_eq!(candidates[0].title, "Artist / Album");
+    }
+
+    #[test]
+    fn parses_xmcd_read_response_with_artids() {
+        let candidate = parse_read_response(
+            "rock",
+            "9f0c2a0d",
+            "210 rock 9f0c2a0d CD database entry follows\n# Artid: abc\n# Artid: def\nDISCID=9F0C2A0D\nDTITLE=Boney M. / Oceans Of Fantasy\nDYEAR=1979\nTTITLE0=Let It All Be Music\nTTITLE1=Gotta Go Home\n.\n",
+        )
+        .unwrap();
+
+        assert_eq!(candidate.disc_id, "9F0C2A0D");
+        assert_eq!(candidate.artist.as_deref(), Some("Boney M."));
+        assert_eq!(candidate.title.as_deref(), Some("Oceans Of Fantasy"));
+        assert_eq!(candidate.year, Some(1979));
+        assert_eq!(candidate.track_titles.len(), 2);
+        assert_eq!(candidate.art_ids, vec!["abc", "def"]);
+    }
+
+    #[tokio::test]
+    async fn lookup_reads_and_filters_matching_candidate() {
+        let (url, requests) = serve_sequence(vec![
+            (
+                "200 OK",
+                "210 Found exact matches, list follows\nrock 9f0c2a0d Boney M. / Oceans Of Fantasy\n.\n",
+            ),
+            (
+                "200 OK",
+                "210 rock 9f0c2a0d CD database entry follows\n# Artid: 11111111-1111-1111-1111-111111111111\nDISCID=9F0C2A0D\nDTITLE=Boney M. / Oceans Of Fantasy\nDYEAR=1979\nTTITLE0=Let It All Be Music\nTTITLE1=Gotta Go Home\n.\n",
+            ),
+        ])
+        .await;
+        let lookup = lookup(url, true);
+
+        let result = lookup
+            .lookup_disc_release(crate::application::ports::DiscReleaseLookupRequest {
+                disc_id: "9F0C2A0D".into(),
+                artist: Some("Boney M.".into()),
+                album_title: Some("Oceans Of Fantasy".into()),
+                year: Some(1979),
+                track_count: 2,
+                track_titles_by_number: vec![
+                    (1, "Let It All Be Music".into()),
+                    (2, "Gotta Go Home".into()),
+                ],
+            })
+            .await
+            .unwrap();
+
+        let DiscReleaseLookupResult::Found {
+            candidates,
+            diagnostic,
+        } = result
+        else {
+            panic!("expected GnuDB match");
+        };
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].art_ids,
+            vec!["11111111-1111-1111-1111-111111111111"]
+        );
+        assert!(diagnostic.contains("GnuDB accepted candidates: 1"));
+        assert_eq!(requests.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn lookup_ignores_mismatched_discid() {
+        let (url, _) = serve_sequence(vec![
+            (
+                "200 OK",
+                "210 Found exact matches, list follows\nrock 9f0c2a0d Boney M. / Oceans Of Fantasy\n.\n",
+            ),
+            (
+                "200 OK",
+                "210 rock 9f0c2a0d CD database entry follows\nDISCID=00000000\nDTITLE=Boney M. / Oceans Of Fantasy\nDYEAR=1979\nTTITLE0=Let It All Be Music\n.\n",
+            ),
+        ])
+        .await;
+        let lookup = lookup(url, true);
+
+        let result = lookup
+            .lookup_disc_release(crate::application::ports::DiscReleaseLookupRequest {
+                disc_id: "9F0C2A0D".into(),
+                artist: Some("Boney M.".into()),
+                album_title: Some("Oceans Of Fantasy".into()),
+                year: Some(1979),
+                track_count: 1,
+                track_titles_by_number: vec![(1, "Let It All Be Music".into())],
+            })
+            .await
+            .unwrap();
+
+        let DiscReleaseLookupResult::NotFound { diagnostic } = result else {
+            panic!("expected no GnuDB match");
+        };
+        assert!(diagnostic.contains("rejected: DISCID mismatch"));
+    }
+
+    #[tokio::test]
+    async fn lookup_reports_api_errors_as_non_matching_result() {
+        let url = serve_once("500 Internal Server Error", "boom").await;
+        let lookup = lookup(url, true);
+
+        let result = lookup
+            .lookup_disc_release(crate::application::ports::DiscReleaseLookupRequest {
+                disc_id: "9F0C2A0D".into(),
+                artist: Some("Boney M.".into()),
+                album_title: Some("Oceans Of Fantasy".into()),
+                year: Some(1979),
+                track_count: 1,
+                track_titles_by_number: vec![(1, "Let It All Be Music".into())],
+            })
+            .await
+            .unwrap();
+
+        let DiscReleaseLookupResult::NotFound { diagnostic } = result else {
+            panic!("expected no GnuDB match");
+        };
+        assert!(diagnostic.contains("HTTP 500"));
+    }
+
+    #[test]
+    fn endpoint_url_is_built_from_server() {
+        let lookup = lookup("4ckgj7jx.gnudb.org".into(), true);
+
+        assert_eq!(
+            lookup.endpoint_url(),
+            "http://4ckgj7jx.gnudb.org/~cddb/cddb.cgi"
+        );
+    }
+
+    fn lookup(server: String, enabled: bool) -> GnudbDiscReleaseLookup {
+        GnudbDiscReleaseLookup::new(&GnudbSettings {
+            disc_lookup_enabled: enabled,
+            server,
+            user_email: "user@example.com".into(),
+        })
+    }
+
+    async fn serve_once(status: &'static str, body: &'static str) -> String {
+        let (url, _) = serve_sequence(vec![(status, body)]).await;
+        url
+    }
+
+    async fn serve_sequence(
+        responses: Vec<(&'static str, &'static str)>,
+    ) -> (String, Arc<Mutex<Vec<String>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let shared_requests = Arc::clone(&requests);
+        let shared_responses = Arc::new(Mutex::new(
+            responses
+                .into_iter()
+                .collect::<VecDeque<(&'static str, &'static str)>>(),
+        ));
+        let queue = Arc::clone(&shared_responses);
+
+        tokio::spawn(async move {
+            loop {
+                let next = { queue.lock().unwrap().pop_front() };
+                let Some((status, body)) = next else {
+                    break;
+                };
+
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = [0_u8; 4096];
+                let bytes_read = socket.read(&mut request).await.unwrap();
+                let request_text = String::from_utf8_lossy(&request[..bytes_read]);
+                shared_requests
+                    .lock()
+                    .unwrap()
+                    .push(request_text.into_owned());
+
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+
+        (format!("http://{addr}"), requests)
+    }
+}

--- a/src/adapters/lidarr_api.rs
+++ b/src/adapters/lidarr_api.rs
@@ -1,17 +1,27 @@
-use std::collections::HashSet;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::application::ports::{
-    ManualImportRequest, ManualImportResult, ManualImportTrigger, QueueSource,
+    CueMetadataHint, DiscReleaseLookup, DiscReleaseLookupRequest, DiscReleaseLookupResult,
+    ManualImportRequest, ManualImportResult, ManualImportTrigger, MusicBrainzDiscLookupRequest,
+    MusicBrainzDiscLookupResult, MusicBrainzDiscRelease, MusicBrainzDiscReleaseLookup,
+    NoopDiscReleaseLookup, NoopMusicBrainzDiscReleaseLookup, QueueSource,
 };
 use crate::bootstrap::settings::LidarrSettings;
 use crate::domain::{FailedImportCandidate, QueueSnapshot};
 
-#[derive(Debug, Clone)]
+const DEFAULT_MUSICBRAINZ_ADD_ALBUM_REFETCH_ATTEMPTS: usize = 5;
+const DEFAULT_MUSICBRAINZ_ADD_ALBUM_REFETCH_DELAY: Duration = Duration::from_secs(1);
+const DEFAULT_LIDARR_COMMAND_POLL_ATTEMPTS: usize = 60;
+const DEFAULT_LIDARR_COMMAND_POLL_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(Clone)]
 pub struct LidarrQueueSource {
     base_url: String,
     api_key: String,
@@ -19,6 +29,14 @@ pub struct LidarrQueueSource {
     max_pages: usize,
     manual_import_enabled: bool,
     client: reqwest::Client,
+    disc_release_lookup: Arc<dyn DiscReleaseLookup>,
+    musicbrainz_disc_release_lookup: Arc<dyn MusicBrainzDiscReleaseLookup>,
+    trust_musicbrainz_disc_lookup: bool,
+    add_missing_musicbrainz_release_group: bool,
+    musicbrainz_add_album_refetch_attempts: usize,
+    musicbrainz_add_album_refetch_delay: Duration,
+    lidarr_command_poll_attempts: usize,
+    lidarr_command_poll_delay: Duration,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -54,7 +72,52 @@ impl LidarrQueueSource {
             max_pages: settings.queue_max_pages.max(1),
             manual_import_enabled: settings.manual_import_enabled,
             client: reqwest::Client::new(),
+            disc_release_lookup: Arc::new(NoopDiscReleaseLookup),
+            musicbrainz_disc_release_lookup: Arc::new(NoopMusicBrainzDiscReleaseLookup),
+            trust_musicbrainz_disc_lookup: false,
+            add_missing_musicbrainz_release_group: false,
+            musicbrainz_add_album_refetch_attempts: DEFAULT_MUSICBRAINZ_ADD_ALBUM_REFETCH_ATTEMPTS,
+            musicbrainz_add_album_refetch_delay: DEFAULT_MUSICBRAINZ_ADD_ALBUM_REFETCH_DELAY,
+            lidarr_command_poll_attempts: DEFAULT_LIDARR_COMMAND_POLL_ATTEMPTS,
+            lidarr_command_poll_delay: DEFAULT_LIDARR_COMMAND_POLL_DELAY,
         }
+    }
+
+    pub fn with_disc_release_lookup(mut self, lookup: Arc<dyn DiscReleaseLookup>) -> Self {
+        self.disc_release_lookup = lookup;
+        self
+    }
+
+    pub fn with_musicbrainz_disc_release_lookup(
+        mut self,
+        lookup: Arc<dyn MusicBrainzDiscReleaseLookup>,
+    ) -> Self {
+        self.musicbrainz_disc_release_lookup = lookup;
+        self
+    }
+
+    pub fn with_musicbrainz_trust_disc_lookup(mut self, enabled: bool) -> Self {
+        self.trust_musicbrainz_disc_lookup = enabled;
+        self
+    }
+
+    pub fn with_musicbrainz_add_missing_release_group(mut self, enabled: bool) -> Self {
+        self.add_missing_musicbrainz_release_group = enabled;
+        self
+    }
+
+    #[cfg(test)]
+    fn with_musicbrainz_add_album_refetch(mut self, attempts: usize, delay: Duration) -> Self {
+        self.musicbrainz_add_album_refetch_attempts = attempts.max(1);
+        self.musicbrainz_add_album_refetch_delay = delay;
+        self
+    }
+
+    #[cfg(test)]
+    fn with_lidarr_command_poll(mut self, attempts: usize, delay: Duration) -> Self {
+        self.lidarr_command_poll_attempts = attempts.max(1);
+        self.lidarr_command_poll_delay = delay;
+        self
     }
 }
 
@@ -174,12 +237,13 @@ impl ManualImportTrigger for LidarrQueueSource {
         let candidates: Vec<ManualImportResource> = serde_json::from_str(&body).map_err(|err| {
             anyhow!("lidarr returned invalid manual import JSON: {err}; body: {body}")
         })?;
-        let files = match select_manual_import_files(&request, candidates)? {
-            Some(files) => files,
-            None => {
-                return Ok(ManualImportResult::Skipped {
-                    reason: "lidarr did not return one complete album release match".into(),
-                });
+        let selection = self
+            .select_manual_import_files(&request, &candidates)
+            .await?;
+        let (files, diagnostic) = match selection {
+            ManualImportSelection::Selected { files, diagnostic } => (files, diagnostic),
+            ManualImportSelection::Skipped { reason, diagnostic } => {
+                return Ok(ManualImportResult::Skipped { reason, diagnostic });
             }
         };
         let imported_track_count = files.len();
@@ -191,6 +255,11 @@ impl ManualImportTrigger for LidarrQueueSource {
         };
         let command_body = serde_json::to_string(&command)
             .map_err(|err| anyhow!("failed serializing lidarr manual import command: {err}"))?;
+        let mut diagnostic = diagnostic;
+        diagnostic.push_str(&format!(
+            "Lidarr manual import command: posting /api/v1/command files={imported_track_count}\n"
+        ));
+        append_lidarr_manual_import_command_files(&mut diagnostic, &command.files);
         let response = self
             .client
             .post(format!("{}/api/v1/command", self.base_url))
@@ -207,13 +276,1456 @@ impl ManualImportTrigger for LidarrQueueSource {
 
         if !status.is_success() {
             return Err(anyhow!(
-                "lidarr returned HTTP {status} for manual import command: {body}"
+                "lidarr returned HTTP {status} for manual import command: {body}\n{diagnostic}"
             ));
+        }
+        let command_response: LidarrCommandResource = serde_json::from_str(&body).map_err(|err| {
+            anyhow!("lidarr returned invalid manual import command JSON: {err}; body: {body}\n{diagnostic}")
+        })?;
+        append_lidarr_command_diagnostic(
+            &mut diagnostic,
+            "Lidarr manual import command accepted",
+            &command_response,
+        );
+        let wait_outcome = self
+            .await_lidarr_command(command_response, &mut diagnostic)
+            .await?;
+        if wait_outcome == CommandWaitOutcome::Completed {
+            verify_manual_import_source_files_moved(&command.files, &mut diagnostic).await?;
         }
 
         Ok(ManualImportResult::Started {
             imported_track_count,
+            diagnostic,
         })
+    }
+}
+
+impl LidarrQueueSource {
+    async fn await_lidarr_command(
+        &self,
+        mut command: LidarrCommandResource,
+        diagnostic: &mut String,
+    ) -> Result<CommandWaitOutcome> {
+        let Some(command_id) = command.positive_id() else {
+            diagnostic.push_str(
+                "Lidarr manual import command polling: skipped because response had no command id\n",
+            );
+            return Ok(CommandWaitOutcome::NotCompleted);
+        };
+        if command.status.is_none() {
+            diagnostic.push_str(
+                "Lidarr manual import command polling: skipped because response had no status\n",
+            );
+            return Ok(CommandWaitOutcome::NotCompleted);
+        }
+
+        for attempt in 1..=self.lidarr_command_poll_attempts {
+            match lidarr_command_outcome(&command) {
+                CommandOutcome::Successful => {
+                    diagnostic.push_str(&format!(
+                        "Lidarr manual import command decision: completed successfully command_id={command_id} attempt={attempt}\n"
+                    ));
+                    return Ok(CommandWaitOutcome::Completed);
+                }
+                CommandOutcome::Failed(reason) => {
+                    diagnostic.push_str(&format!(
+                        "Lidarr manual import command decision: failed command_id={command_id} attempt={attempt}: {reason}\n"
+                    ));
+                    return Err(anyhow!(
+                        "lidarr manual import command failed: {reason}\n{diagnostic}"
+                    ));
+                }
+                CommandOutcome::Running => {}
+            }
+
+            if attempt == self.lidarr_command_poll_attempts {
+                diagnostic.push_str(&format!(
+                    "Lidarr manual import command decision: still running command_id={command_id} attempts={attempt}\n"
+                ));
+                return Ok(CommandWaitOutcome::NotCompleted);
+            }
+
+            if attempt > 1 || !self.lidarr_command_poll_delay.is_zero() {
+                tokio::time::sleep(self.lidarr_command_poll_delay).await;
+            }
+            command = self
+                .fetch_lidarr_command(command_id, diagnostic, attempt)
+                .await?;
+        }
+
+        Ok(CommandWaitOutcome::NotCompleted)
+    }
+
+    async fn fetch_lidarr_command(
+        &self,
+        command_id: i64,
+        diagnostic: &mut String,
+        attempt: usize,
+    ) -> Result<LidarrCommandResource> {
+        let response = self
+            .client
+            .get(format!("{}/api/v1/command/{command_id}", self.base_url))
+            .header("x-api-key", &self.api_key)
+            .send()
+            .await
+            .map_err(|err| {
+                anyhow!("failed requesting lidarr manual import command status {command_id}: {err}")
+            })?;
+        let status = response.status();
+        let body = response.text().await.map_err(|err| {
+            anyhow!("failed reading lidarr manual import command status {command_id}: {err}")
+        })?;
+        if !status.is_success() {
+            return Err(anyhow!(
+                "lidarr returned HTTP {status} for manual import command status {command_id}: {body}\n{diagnostic}"
+            ));
+        }
+        let command = serde_json::from_str(&body).map_err(|err| {
+            anyhow!(
+                "lidarr returned invalid manual import command status JSON for {command_id}: {err}; body: {body}\n{diagnostic}"
+            )
+        })?;
+        append_lidarr_command_diagnostic(
+            diagnostic,
+            &format!("Lidarr manual import command poll attempt={attempt}"),
+            &command,
+        );
+        Ok(command)
+    }
+
+    async fn select_manual_import_files(
+        &self,
+        request: &ManualImportRequest,
+        candidates: &[ManualImportResource],
+    ) -> Result<ManualImportSelection> {
+        match select_manual_import_files(request, candidates) {
+            ManualImportSelection::Selected { files, diagnostic } => {
+                Ok(ManualImportSelection::Selected { files, diagnostic })
+            }
+            ManualImportSelection::Skipped { reason, diagnostic } => {
+                self.select_fallback_manual_import_files(request, candidates, reason, diagnostic)
+                    .await
+            }
+        }
+    }
+
+    async fn select_fallback_manual_import_files(
+        &self,
+        request: &ManualImportRequest,
+        candidates: &[ManualImportResource],
+        direct_reason: String,
+        mut diagnostic: String,
+    ) -> Result<ManualImportSelection> {
+        let fallback = match fallback_prerequisites(request, candidates) {
+            Ok(fallback) => fallback,
+            Err(reason) => {
+                diagnostic.push_str("Fallback manual import: skipped\n");
+                diagnostic.push_str(&format!("Fallback reason: {reason}\n"));
+                return Ok(ManualImportSelection::Skipped {
+                    reason: direct_reason,
+                    diagnostic,
+                });
+            }
+        };
+
+        diagnostic.push_str("Fallback manual import: evaluating Lidarr album data\n");
+        diagnostic.push_str(&format!("Fallback artist id: {}\n", fallback.artist_id));
+        let hints = AlbumMatchHints::from_request(request);
+        append_album_match_hints(&mut diagnostic, &hints);
+
+        let albums = self.fetch_artist_albums(fallback.artist_id).await?;
+        let mut musicbrainz_add_attempted = false;
+        let album_match = match self
+            .select_fallback_album(
+                &fallback.artist,
+                &albums,
+                &hints,
+                &mut diagnostic,
+                &mut musicbrainz_add_attempted,
+            )
+            .await
+        {
+            Ok(album_match) => album_match,
+            Err(reason) => {
+                if !musicbrainz_add_attempted {
+                    if let Some(album_match) = self
+                        .try_add_missing_musicbrainz_release_group(
+                            &fallback.artist,
+                            lidarr_source_artist(&albums, fallback.artist_id),
+                            &hints,
+                            &mut diagnostic,
+                            &mut musicbrainz_add_attempted,
+                        )
+                        .await
+                        .map_err(|err| anyhow!(err))?
+                    {
+                        return self
+                            .manual_import_selection_for_album_match(
+                                request,
+                                &fallback,
+                                album_match,
+                                diagnostic,
+                            )
+                            .await;
+                    }
+                }
+                diagnostic.push_str(&format!("Fallback decision: skipped: {reason}\n"));
+                return Ok(ManualImportSelection::Skipped { reason, diagnostic });
+            }
+        };
+
+        self.manual_import_selection_for_album_match(request, &fallback, album_match, diagnostic)
+            .await
+    }
+
+    async fn manual_import_selection_for_album_match(
+        &self,
+        request: &ManualImportRequest,
+        fallback: &FallbackPrerequisites<'_>,
+        album_match: SelectedFallbackAlbum,
+        mut diagnostic: String,
+    ) -> Result<ManualImportSelection> {
+        let tracks = self.fetch_album_tracks(album_match.album_id).await?;
+        let mapped_tracks =
+            match map_generated_tracks_to_lidarr_tracks(request, &tracks, &mut diagnostic) {
+                Ok(mapped_tracks) => mapped_tracks,
+                Err(reason) => {
+                    diagnostic.push_str(&format!("Fallback decision: skipped: {reason}\n"));
+                    return Ok(ManualImportSelection::Skipped { reason, diagnostic });
+                }
+            };
+
+        let mut files = Vec::with_capacity(fallback.candidates_by_path.len());
+        for generated_track in &request.generated_tracks {
+            let path = generated_track.to_string_lossy().to_string();
+            let Some(candidate) = fallback.candidates_by_path.get(&path) else {
+                let reason = format!("{} no longer has a fallback candidate", path);
+                diagnostic.push_str(&format!("Fallback decision: skipped: {reason}\n"));
+                return Ok(ManualImportSelection::Skipped { reason, diagnostic });
+            };
+            let Some(quality) = candidate.quality.clone() else {
+                let reason = format!("{} is missing quality", candidate.path);
+                diagnostic.push_str(&format!("Fallback decision: skipped: {reason}\n"));
+                return Ok(ManualImportSelection::Skipped { reason, diagnostic });
+            };
+            let Some(track_id) = mapped_tracks.get(&path).copied() else {
+                let reason = format!("{} was not mapped to a Lidarr track", path);
+                diagnostic.push_str(&format!("Fallback decision: skipped: {reason}\n"));
+                return Ok(ManualImportSelection::Skipped { reason, diagnostic });
+            };
+            files.push(ManualImportFile {
+                path: candidate.path.clone(),
+                artist_id: fallback.artist_id,
+                album_id: album_match.album_id,
+                album_release_id: album_match.album_release_id,
+                track_ids: vec![track_id],
+                quality,
+                indexer_flags: candidate.indexer_flags,
+                download_id: request.download.download_id.clone(),
+                disable_release_switching: false,
+            });
+        }
+
+        diagnostic.push_str(&format!(
+            "Fallback decision: selected album_id={} album_release_id={} for {} track(s)\n",
+            album_match.album_id,
+            album_match.album_release_id,
+            files.len()
+        ));
+        Ok(ManualImportSelection::Selected { files, diagnostic })
+    }
+
+    async fn fetch_artist_albums(&self, artist_id: i64) -> Result<Vec<LidarrAlbumResource>> {
+        let response = self
+            .client
+            .get(format!("{}/api/v1/album", self.base_url))
+            .query(&[("artistId", artist_id)])
+            .header("x-api-key", &self.api_key)
+            .send()
+            .await
+            .map_err(|err| {
+                anyhow!("failed requesting lidarr albums for artist {artist_id}: {err}")
+            })?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|err| anyhow!("failed reading lidarr albums for artist {artist_id}: {err}"))?;
+        if !status.is_success() {
+            return Err(anyhow!(
+                "lidarr returned HTTP {status} for artist albums: {body}"
+            ));
+        }
+        serde_json::from_str(&body)
+            .map_err(|err| anyhow!("lidarr returned invalid album JSON: {err}; body: {body}"))
+    }
+
+    async fn fetch_album_tracks(&self, album_id: i64) -> Result<Vec<LidarrTrackResource>> {
+        let response = self
+            .client
+            .get(format!("{}/api/v1/track", self.base_url))
+            .query(&[("albumId", album_id)])
+            .header("x-api-key", &self.api_key)
+            .send()
+            .await
+            .map_err(|err| {
+                anyhow!("failed requesting lidarr tracks for album {album_id}: {err}")
+            })?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|err| anyhow!("failed reading lidarr tracks for album {album_id}: {err}"))?;
+        if !status.is_success() {
+            return Err(anyhow!(
+                "lidarr returned HTTP {status} for album tracks: {body}"
+            ));
+        }
+        serde_json::from_str(&body)
+            .map_err(|err| anyhow!("lidarr returned invalid track JSON: {err}; body: {body}"))
+    }
+
+    async fn select_fallback_album(
+        &self,
+        artist: &ManualImportArtist,
+        albums: &[LidarrAlbumResource],
+        hints: &AlbumMatchHints,
+        diagnostic: &mut String,
+        musicbrainz_add_attempted: &mut bool,
+    ) -> std::result::Result<SelectedFallbackAlbum, String> {
+        let candidate = match select_fallback_album_candidate(albums, hints, diagnostic) {
+            Ok(candidate) => candidate,
+            Err(reason)
+                if self.trust_musicbrainz_disc_lookup
+                    && reason == "multiple Lidarr albums matched fallback hints" =>
+            {
+                diagnostic.push_str(
+                    "Fallback album match was ambiguous; trying trusted MusicBrainz widening\n",
+                );
+                if let Some(album_match) = self
+                    .select_trusted_album_with_musicbrainz_lookup(albums, hints, diagnostic)
+                    .await?
+                {
+                    return Ok(SelectedFallbackAlbum {
+                        album_id: album_match.album.id,
+                        album_release_id: album_match.release.id,
+                    });
+                }
+                return Err(reason);
+            }
+            Err(reason) => return Err(reason),
+        };
+        if candidate.releases.len() > 1 {
+            if let Some(album_match) = self
+                .select_album_with_musicbrainz_lookup(
+                    albums,
+                    &candidate,
+                    artist,
+                    hints,
+                    diagnostic,
+                    musicbrainz_add_attempted,
+                )
+                .await?
+            {
+                return Ok(album_match);
+            }
+        }
+
+        if !candidate.requires_disc_lookup {
+            if let Some(release) = select_fallback_release(candidate.releases.clone()) {
+                diagnostic.push_str(&format!(
+                    "Fallback selected album: album_id={} title={} release_id={}\n",
+                    candidate.album.id, candidate.album.title, release.id
+                ));
+                return Ok(SelectedFallbackAlbum {
+                    album_id: candidate.album.id,
+                    album_release_id: release.id,
+                });
+            }
+        }
+
+        let release = self
+            .select_release_with_disc_lookup(candidate.releases, hints, diagnostic)
+            .await?
+            .ok_or_else(|| "multiple Lidarr album releases matched fallback hints".to_owned())?;
+        diagnostic.push_str(&format!(
+            "Fallback selected album using disc lookup: album_id={} title={} release_id={} foreign_release_id={}\n",
+            candidate.album.id,
+            candidate.album.title,
+            release.id,
+            release.foreign_release_id.as_deref().unwrap_or("-")
+        ));
+        Ok(SelectedFallbackAlbum {
+            album_id: candidate.album.id,
+            album_release_id: release.id,
+        })
+    }
+
+    async fn select_album_with_musicbrainz_lookup<'a>(
+        &self,
+        albums: &'a [LidarrAlbumResource],
+        primary: &FallbackAlbumCandidate<'a>,
+        artist: &ManualImportArtist,
+        hints: &AlbumMatchHints,
+        diagnostic: &mut String,
+        musicbrainz_add_attempted: &mut bool,
+    ) -> std::result::Result<Option<SelectedFallbackAlbum>, String> {
+        diagnostic.push_str("Fallback MusicBrainz release lookup: evaluating\n");
+        diagnostic.push_str(&format!(
+            "Fallback MusicBrainz trusted widening: {}\n",
+            self.trust_musicbrainz_disc_lookup
+        ));
+        diagnostic.push_str("Fallback Lidarr releases for MusicBrainz/GnuDB:\n");
+        for release in &primary.releases {
+            diagnostic.push_str(&format!(
+                "  - release_id={} foreign_release_id={} title={} track_count={} duration={} format={} country=[{}] label=[{}] monitored={}\n",
+                release.id,
+                release.foreign_release_id.as_deref().unwrap_or("-"),
+                release.title.as_deref().unwrap_or("-"),
+                release.track_count,
+                release.duration,
+                release.format.as_deref().unwrap_or("-"),
+                release.country.join(", "),
+                release.label.join(", "),
+                release.monitored
+            ));
+        }
+
+        let Some(musicbrainz_releases) =
+            self.lookup_musicbrainz_releases(hints, diagnostic).await?
+        else {
+            return Ok(None);
+        };
+
+        if let Some(release) = select_musicbrainz_release_for_releases(
+            &primary.releases,
+            hints,
+            &musicbrainz_releases,
+            diagnostic,
+        )? {
+            diagnostic.push_str(&format!(
+                "Fallback selected album using MusicBrainz: album_id={} title={} release_id={} foreign_release_id={}\n",
+                primary.album.id,
+                primary.album.title,
+                release.id,
+                release.foreign_release_id.as_deref().unwrap_or("-")
+            ));
+            return Ok(Some(SelectedFallbackAlbum {
+                album_id: primary.album.id,
+                album_release_id: release.id,
+            }));
+        }
+
+        if self.trust_musicbrainz_disc_lookup {
+            if let Some(album_match) = select_trusted_musicbrainz_album_release(
+                albums,
+                hints,
+                &musicbrainz_releases,
+                diagnostic,
+            ) {
+                return Ok(Some(SelectedFallbackAlbum {
+                    album_id: album_match.album.id,
+                    album_release_id: album_match.release.id,
+                }));
+            }
+        }
+
+        self.try_add_missing_musicbrainz_release_group_from_releases(
+            artist,
+            primary.album.artist.as_ref(),
+            hints,
+            &musicbrainz_releases,
+            diagnostic,
+            musicbrainz_add_attempted,
+        )
+        .await
+    }
+
+    async fn select_trusted_album_with_musicbrainz_lookup<'a>(
+        &self,
+        albums: &'a [LidarrAlbumResource],
+        hints: &AlbumMatchHints,
+        diagnostic: &mut String,
+    ) -> std::result::Result<Option<FallbackAlbumMatch<'a>>, String> {
+        diagnostic.push_str("Fallback MusicBrainz release lookup: evaluating\n");
+        diagnostic.push_str(&format!(
+            "Fallback MusicBrainz trusted widening: {}\n",
+            self.trust_musicbrainz_disc_lookup
+        ));
+        let Some(musicbrainz_releases) =
+            self.lookup_musicbrainz_releases(hints, diagnostic).await?
+        else {
+            return Ok(None);
+        };
+        Ok(select_trusted_musicbrainz_album_release(
+            albums,
+            hints,
+            &musicbrainz_releases,
+            diagnostic,
+        ))
+    }
+
+    async fn try_add_missing_musicbrainz_release_group(
+        &self,
+        artist: &ManualImportArtist,
+        source_artist: Option<&Value>,
+        hints: &AlbumMatchHints,
+        diagnostic: &mut String,
+        musicbrainz_add_attempted: &mut bool,
+    ) -> std::result::Result<Option<SelectedFallbackAlbum>, String> {
+        diagnostic.push_str(&format!(
+            "Fallback MusicBrainz add missing release group: {}\n",
+            self.add_missing_musicbrainz_release_group
+        ));
+        if !self.add_missing_musicbrainz_release_group {
+            diagnostic.push_str(
+                "MusicBrainz add missing release group decision: disabled, falling through\n",
+            );
+            return Ok(None);
+        }
+
+        let Some(musicbrainz_releases) =
+            self.lookup_musicbrainz_releases(hints, diagnostic).await?
+        else {
+            diagnostic.push_str(
+                "MusicBrainz add missing release group decision: no MusicBrainz releases, falling through\n",
+            );
+            return Ok(None);
+        };
+
+        self.try_add_missing_musicbrainz_release_group_from_releases(
+            artist,
+            source_artist,
+            hints,
+            &musicbrainz_releases,
+            diagnostic,
+            musicbrainz_add_attempted,
+        )
+        .await
+    }
+
+    async fn try_add_missing_musicbrainz_release_group_from_releases(
+        &self,
+        artist: &ManualImportArtist,
+        source_artist: Option<&Value>,
+        hints: &AlbumMatchHints,
+        musicbrainz_releases: &[MusicBrainzDiscRelease],
+        diagnostic: &mut String,
+        musicbrainz_add_attempted: &mut bool,
+    ) -> std::result::Result<Option<SelectedFallbackAlbum>, String> {
+        diagnostic.push_str(&format!(
+            "Fallback MusicBrainz add missing release group: {}\n",
+            self.add_missing_musicbrainz_release_group
+        ));
+        if !self.add_missing_musicbrainz_release_group {
+            diagnostic.push_str(
+                "MusicBrainz add missing release group decision: disabled, falling through\n",
+            );
+            return Ok(None);
+        }
+        *musicbrainz_add_attempted = true;
+
+        let release_group_id =
+            match single_musicbrainz_release_group_id(musicbrainz_releases, diagnostic) {
+                Some(release_group_id) => release_group_id,
+                None => return Ok(None),
+            };
+
+        let Some(mut album) = self
+            .search_lidarr_album_by_release_group(&release_group_id, diagnostic)
+            .await
+        else {
+            return Ok(None);
+        };
+        let search_release_count = album.releases.len();
+        let artist_payload = source_artist
+            .cloned()
+            .or_else(|| album.artist.clone())
+            .or_else(|| serde_json::to_value(artist).ok());
+        album.artist_id = artist.id;
+        album.artist = artist_payload;
+        album.releases.clear();
+        album.monitored = Some(false);
+        album.add_options = Some(LidarrAddAlbumOptions {
+            add_type: "manual".to_owned(),
+            search_for_new_album: false,
+        });
+        diagnostic.push_str(&format!(
+            "MusicBrainz add missing release group: prepared Lidarr add album payload artist_source={} stripped_search_releases={}\n",
+            if source_artist.is_some() {
+                "lidarr-album"
+            } else if album.artist.is_some() {
+                "search-album-or-manual-import"
+            } else {
+                "none"
+            },
+            search_release_count
+        ));
+
+        let Some(added_album) = self.add_lidarr_album(album, diagnostic).await else {
+            return Ok(None);
+        };
+
+        let added_album_id = (added_album.id > 0).then_some(added_album.id);
+        let added_foreign_album_id = added_album
+            .foreign_album_id
+            .as_deref()
+            .unwrap_or(&release_group_id);
+        let Some(album) = self
+            .fetch_added_musicbrainz_album(
+                artist.id,
+                added_album_id,
+                added_foreign_album_id,
+                hints.track_count,
+                diagnostic,
+            )
+            .await
+        else {
+            return Ok(None);
+        };
+
+        let releases = matching_releases(&album, hints.track_count);
+        diagnostic.push_str(&format!(
+            "MusicBrainz added Lidarr album candidate: album_id={} title={} release_group_id={} matching_releases={}\n",
+            album.id,
+            album.title,
+            album.foreign_album_id.as_deref().unwrap_or("-"),
+            releases.len()
+        ));
+        if releases.is_empty() {
+            diagnostic.push_str(
+                "MusicBrainz add missing release group decision: added album has no compatible release, falling through\n",
+            );
+            return Ok(None);
+        }
+
+        let Some(release) = select_musicbrainz_release_for_releases(
+            &releases,
+            hints,
+            musicbrainz_releases,
+            diagnostic,
+        )?
+        else {
+            diagnostic.push_str(
+                "MusicBrainz add missing release group decision: no compatible added Lidarr release, falling through\n",
+            );
+            return Ok(None);
+        };
+
+        diagnostic.push_str(&format!(
+            "MusicBrainz add missing release group decision: added release-group selected album_id={} album_title={} release_id={} foreign_release_id={}\n",
+            album.id,
+            album.title,
+            release.id,
+            release.foreign_release_id.as_deref().unwrap_or("-")
+        ));
+        Ok(Some(SelectedFallbackAlbum {
+            album_id: album.id,
+            album_release_id: release.id,
+        }))
+    }
+
+    async fn fetch_added_musicbrainz_album(
+        &self,
+        artist_id: i64,
+        added_album_id: Option<i64>,
+        added_foreign_album_id: &str,
+        track_count: usize,
+        diagnostic: &mut String,
+    ) -> Option<LidarrAlbumResource> {
+        for attempt in 1..=self.musicbrainz_add_album_refetch_attempts {
+            let albums = match self.fetch_artist_albums(artist_id).await {
+                Ok(albums) => albums,
+                Err(err) => {
+                    diagnostic.push_str(&format!(
+                        "MusicBrainz add missing release group decision: failed refetching Lidarr albums after add attempt={attempt}: {err}\n",
+                    ));
+                    return None;
+                }
+            };
+            let album = albums.into_iter().find(|album| {
+                added_album_id.is_some_and(|id| album.id == id)
+                    || album
+                        .foreign_album_id
+                        .as_deref()
+                        .is_some_and(|id| id.eq_ignore_ascii_case(added_foreign_album_id))
+            });
+            let Some(album) = album else {
+                diagnostic.push_str(&format!(
+                    "MusicBrainz add missing release group refetch attempt={attempt}: added album not present foreign_album_id={added_foreign_album_id}\n",
+                ));
+                if attempt < self.musicbrainz_add_album_refetch_attempts {
+                    tokio::time::sleep(self.musicbrainz_add_album_refetch_delay).await;
+                    continue;
+                }
+                diagnostic.push_str(&format!(
+                    "MusicBrainz add missing release group decision: added album was not present after refetch foreign_album_id={added_foreign_album_id}\n",
+                ));
+                return None;
+            };
+
+            let matching_releases = matching_releases(&album, track_count);
+            diagnostic.push_str(&format!(
+                "MusicBrainz add missing release group refetch attempt={attempt}: album_id={} title={} releases={} matching_releases={}\n",
+                album.id,
+                album.title,
+                album.releases.len(),
+                matching_releases.len()
+            ));
+            if !matching_releases.is_empty()
+                || attempt == self.musicbrainz_add_album_refetch_attempts
+            {
+                return Some(album);
+            }
+
+            tokio::time::sleep(self.musicbrainz_add_album_refetch_delay).await;
+        }
+
+        None
+    }
+
+    async fn search_lidarr_album_by_release_group(
+        &self,
+        release_group_id: &str,
+        diagnostic: &mut String,
+    ) -> Option<LidarrAlbumResource> {
+        let term = format!("lidarr:{release_group_id}");
+        diagnostic.push_str(&format!(
+            "MusicBrainz add missing release group search: path=/api/v1/search query=term={term}\n"
+        ));
+        let response = match self
+            .client
+            .get(format!("{}/api/v1/search", self.base_url))
+            .query(&[("term", term.as_str())])
+            .header("x-api-key", &self.api_key)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(err) => {
+                diagnostic.push_str(&format!(
+                    "MusicBrainz add missing release group decision: failed requesting Lidarr search: {err}\n",
+                ));
+                return None;
+            }
+        };
+        let status = response.status();
+        let body = match response.text().await {
+            Ok(body) => body,
+            Err(err) => {
+                diagnostic.push_str(&format!(
+                    "MusicBrainz add missing release group decision: failed reading Lidarr search: {err}\n",
+                ));
+                return None;
+            }
+        };
+        if !status.is_success() {
+            diagnostic.push_str(&format!(
+                "MusicBrainz add missing release group decision: Lidarr search returned HTTP {status}: {body}\n",
+            ));
+            return None;
+        }
+
+        let results: Vec<LidarrSearchResource> = match serde_json::from_str(&body) {
+            Ok(results) => results,
+            Err(err) => {
+                diagnostic.push_str(&format!(
+                    "MusicBrainz add missing release group decision: invalid Lidarr search JSON: {err}; body: {body}\n",
+                ));
+                return None;
+            }
+        };
+        diagnostic.push_str(&format!(
+            "MusicBrainz add missing release group search result count: {}\n",
+            results.len()
+        ));
+        let matching = results
+            .into_iter()
+            .filter_map(|result| result.album)
+            .inspect(|album| {
+                diagnostic.push_str(&format!(
+                    "  - search album title={} foreign_album_id={} id={}\n",
+                    album.title,
+                    album.foreign_album_id.as_deref().unwrap_or("-"),
+                    album.id
+                ));
+            })
+            .filter(|album| {
+                album
+                    .foreign_album_id
+                    .as_deref()
+                    .is_some_and(|id| id.eq_ignore_ascii_case(release_group_id))
+            })
+            .collect::<Vec<_>>();
+        if matching.len() != 1 {
+            diagnostic.push_str(&format!(
+                "MusicBrainz add missing release group decision: expected one matching Lidarr search album, got {}\n",
+                matching.len()
+            ));
+            return None;
+        }
+        diagnostic.push_str(
+            "MusicBrainz add missing release group decision: Lidarr search album accepted\n",
+        );
+        matching.into_iter().next()
+    }
+
+    async fn add_lidarr_album(
+        &self,
+        album: LidarrAlbumResource,
+        diagnostic: &mut String,
+    ) -> Option<LidarrAlbumResource> {
+        diagnostic.push_str("MusicBrainz add missing release group: POST /api/v1/album monitored=false addType=manual searchForNewAlbum=false\n");
+        let body = match serde_json::to_string(&album) {
+            Ok(body) => body,
+            Err(err) => {
+                diagnostic.push_str(&format!(
+                    "MusicBrainz add missing release group decision: failed serializing Lidarr album add request: {err}\n",
+                ));
+                return None;
+            }
+        };
+        let response = match self
+            .client
+            .post(format!("{}/api/v1/album", self.base_url))
+            .header("x-api-key", &self.api_key)
+            .header("content-type", "application/json")
+            .body(body)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(err) => {
+                diagnostic.push_str(&format!(
+                    "MusicBrainz add missing release group decision: failed posting Lidarr album: {err}\n",
+                ));
+                return None;
+            }
+        };
+        let status = response.status();
+        let body = match response.text().await {
+            Ok(body) => body,
+            Err(err) => {
+                diagnostic.push_str(&format!(
+                    "MusicBrainz add missing release group decision: failed reading Lidarr add album response: {err}\n",
+                ));
+                return None;
+            }
+        };
+        if !status.is_success() {
+            diagnostic.push_str(&format!(
+                "MusicBrainz add missing release group decision: Lidarr add album returned HTTP {status}: {body}\n",
+            ));
+            return None;
+        }
+        let album: LidarrAlbumResource = match serde_json::from_str(&body) {
+            Ok(album) => album,
+            Err(err) => {
+                diagnostic.push_str(&format!(
+                    "MusicBrainz add missing release group decision: invalid Lidarr add album JSON: {err}; body: {body}\n",
+                ));
+                return None;
+            }
+        };
+        diagnostic.push_str(&format!(
+            "MusicBrainz add missing release group: added album_id={} title={} foreign_album_id={}\n",
+            album.id,
+            album.title,
+            album.foreign_album_id.as_deref().unwrap_or("-")
+        ));
+        Some(album)
+    }
+
+    async fn select_release_with_disc_lookup<'a>(
+        &self,
+        releases: Vec<&'a LidarrAlbumRelease>,
+        hints: &AlbumMatchHints,
+        diagnostic: &mut String,
+    ) -> std::result::Result<Option<&'a LidarrAlbumRelease>, String> {
+        diagnostic.push_str("Fallback GnuDB release lookup: evaluating\n");
+        diagnostic.push_str("Fallback Lidarr releases for GnuDB:\n");
+        for release in &releases {
+            diagnostic.push_str(&format!(
+                "  - release_id={} foreign_release_id={} title={} track_count={} duration={} format={} country=[{}] label=[{}] monitored={}\n",
+                release.id,
+                release.foreign_release_id.as_deref().unwrap_or("-"),
+                release.title.as_deref().unwrap_or("-"),
+                release.track_count,
+                release.duration,
+                release.format.as_deref().unwrap_or("-"),
+                release.country.join(", "),
+                release.label.join(", "),
+                release.monitored
+            ));
+        }
+
+        let Some(disc_id) = hints.disc_id.as_ref().filter(|disc_id| !disc_id.is_empty()) else {
+            diagnostic
+                .push_str("Fallback GnuDB release lookup: skipped because CUE DISCID is missing\n");
+            return Ok(None);
+        };
+
+        let result = self
+            .disc_release_lookup
+            .lookup_disc_release(DiscReleaseLookupRequest {
+                disc_id: disc_id.clone(),
+                artist: hints.artist.clone(),
+                album_title: hints.album_title.clone(),
+                year: hints.year,
+                track_count: hints.track_count,
+                track_titles_by_number: hints
+                    .track_titles_by_number
+                    .iter()
+                    .map(|(number, title)| (*number, title.clone()))
+                    .collect(),
+            })
+            .await
+            .map_err(|err| format!("GnuDB lookup failed: {err}"))?;
+
+        match result {
+            DiscReleaseLookupResult::Disabled {
+                diagnostic: lookup_diagnostic,
+            }
+            | DiscReleaseLookupResult::NotFound {
+                diagnostic: lookup_diagnostic,
+            } => {
+                diagnostic.push_str(&lookup_diagnostic);
+                Ok(None)
+            }
+            DiscReleaseLookupResult::Found {
+                candidates,
+                diagnostic: lookup_diagnostic,
+            } => {
+                diagnostic.push_str(&lookup_diagnostic);
+                let release_by_foreign_id = releases
+                    .iter()
+                    .filter_map(|release| {
+                        Some((
+                            release.foreign_release_id.as_deref()?.to_ascii_lowercase(),
+                            *release,
+                        ))
+                    })
+                    .collect::<HashMap<_, _>>();
+                let mut matches = Vec::new();
+                for candidate in candidates {
+                    let matching_art_ids = candidate
+                        .art_ids
+                        .iter()
+                        .filter_map(|art_id| {
+                            release_by_foreign_id
+                                .get(&art_id.to_ascii_lowercase())
+                                .copied()
+                                .map(|release| (art_id.clone(), release))
+                        })
+                        .collect::<Vec<_>>();
+                    diagnostic.push_str(&format!(
+                        "GnuDB candidate intersection: category={} id={} art_ids=[{}] matches={}\n",
+                        candidate.category,
+                        candidate.entry_id,
+                        candidate.art_ids.join(", "),
+                        matching_art_ids.len()
+                    ));
+                    if matching_art_ids.len() == 1 {
+                        matches.push(matching_art_ids[0].clone());
+                    }
+                }
+
+                if matches.len() == 1 {
+                    diagnostic.push_str(&format!(
+                        "GnuDB selected foreign_release_id={} release_id={}\n",
+                        matches[0].0, matches[0].1.id
+                    ));
+                    Ok(Some(matches[0].1))
+                } else {
+                    diagnostic.push_str(&format!(
+                        "GnuDB release lookup did not produce exactly one Lidarr release match: {}\n",
+                        matches.len()
+                    ));
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    async fn lookup_musicbrainz_releases(
+        &self,
+        hints: &AlbumMatchHints,
+        diagnostic: &mut String,
+    ) -> std::result::Result<Option<Vec<MusicBrainzDiscRelease>>, String> {
+        let cue_paths = hints.cue_paths.clone();
+        if cue_paths.is_empty() {
+            diagnostic.push_str(
+                "Fallback MusicBrainz release lookup: skipped because no CUE paths are available\n",
+            );
+            return Ok(None);
+        }
+
+        let result = self
+            .musicbrainz_disc_release_lookup
+            .lookup_musicbrainz_disc_releases(MusicBrainzDiscLookupRequest { cue_paths })
+            .await
+            .map_err(|err| format!("MusicBrainz lookup failed: {err}"))?;
+
+        match result {
+            MusicBrainzDiscLookupResult::Disabled {
+                diagnostic: lookup_diagnostic,
+            }
+            | MusicBrainzDiscLookupResult::NotFound {
+                diagnostic: lookup_diagnostic,
+            } => {
+                diagnostic.push_str(&lookup_diagnostic);
+                diagnostic.push_str("Fallback MusicBrainz decision: fell through to GnuDB\n");
+                Ok(None)
+            }
+            MusicBrainzDiscLookupResult::Found {
+                releases: musicbrainz_releases,
+                diagnostic: lookup_diagnostic,
+            } => {
+                diagnostic.push_str(&lookup_diagnostic);
+                Ok(Some(musicbrainz_releases))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct MusicBrainzReleaseScore {
+    exact_mbid: bool,
+    monitored: bool,
+    track_count_compatible: bool,
+    format_preference: i32,
+    metadata_completeness: i32,
+}
+
+struct RankedMusicBrainzRelease<'a> {
+    release: &'a LidarrAlbumRelease,
+    foreign_release_id: String,
+    score: MusicBrainzReleaseScore,
+}
+
+struct RankedTrustedMusicBrainzRelease<'a> {
+    album: &'a LidarrAlbumResource,
+    ranked: RankedMusicBrainzRelease<'a>,
+}
+
+fn single_musicbrainz_release_group_id(
+    musicbrainz_releases: &[MusicBrainzDiscRelease],
+    diagnostic: &mut String,
+) -> Option<String> {
+    let mut ids = Vec::new();
+    let mut missing = 0_usize;
+    for release in musicbrainz_releases {
+        let Some(id) = release.release_group_id.as_deref() else {
+            missing += 1;
+            continue;
+        };
+        let normalized = id.to_ascii_lowercase();
+        if !ids.contains(&normalized) {
+            ids.push(normalized);
+        }
+    }
+
+    diagnostic.push_str(&format!(
+        "MusicBrainz add missing release group distinct release_group_ids=[{}] missing_release_group_ids={}\n",
+        ids.join(", "),
+        missing
+    ));
+    if missing > 0 {
+        diagnostic.push_str(
+            "MusicBrainz add missing release group decision: skipped because at least one MusicBrainz release lacks a release-group ID\n",
+        );
+        return None;
+    }
+    if ids.len() != 1 {
+        diagnostic.push_str(&format!(
+            "MusicBrainz add missing release group decision: expected one distinct release-group ID, got {}\n",
+            ids.len()
+        ));
+        return None;
+    }
+    ids.into_iter().next()
+}
+
+fn select_musicbrainz_release_for_releases<'a>(
+    releases: &[&'a LidarrAlbumRelease],
+    hints: &AlbumMatchHints,
+    musicbrainz_releases: &[MusicBrainzDiscRelease],
+    diagnostic: &mut String,
+) -> std::result::Result<Option<&'a LidarrAlbumRelease>, String> {
+    let mut releases_by_foreign_id: HashMap<String, Vec<&LidarrAlbumRelease>> = HashMap::new();
+    for release in releases {
+        if let Some(foreign_release_id) = release.foreign_release_id.as_deref() {
+            releases_by_foreign_id
+                .entry(foreign_release_id.to_ascii_lowercase())
+                .or_default()
+                .push(*release);
+        }
+    }
+
+    let mut matches = Vec::new();
+    for musicbrainz_release in musicbrainz_releases {
+        let id = musicbrainz_release.id.to_ascii_lowercase();
+        let matched = releases_by_foreign_id
+            .get(&id)
+            .filter(|releases| releases.len() == 1)
+            .map(|releases| releases[0]);
+        let match_count = releases_by_foreign_id.get(&id).map_or(0, Vec::len);
+        diagnostic.push_str(&format!(
+            "MusicBrainz candidate intersection: release_id={} title={} media_count={} matches={}\n",
+            musicbrainz_release.id,
+            musicbrainz_release.title.as_deref().unwrap_or("-"),
+            musicbrainz_release.media_count,
+            match_count
+        ));
+        if let Some(release) = matched {
+            matches.push((musicbrainz_release, release));
+        }
+    }
+
+    if matches.len() == 1 {
+        diagnostic.push_str(&format!(
+            "MusicBrainz decision: exact single MBID selected foreign_release_id={} release_id={}\n",
+            matches[0].0.id, matches[0].1.id
+        ));
+        Ok(Some(matches[0].1))
+    } else {
+        diagnostic.push_str(&format!(
+            "MusicBrainz exact intersection count: {}\n",
+            matches.len()
+        ));
+        select_ranked_musicbrainz_release(
+            releases,
+            hints,
+            musicbrainz_releases,
+            matches,
+            diagnostic,
+        )
+    }
+}
+
+fn select_trusted_musicbrainz_album_release<'a>(
+    albums: &'a [LidarrAlbumResource],
+    hints: &AlbumMatchHints,
+    musicbrainz_releases: &[MusicBrainzDiscRelease],
+    diagnostic: &mut String,
+) -> Option<FallbackAlbumMatch<'a>> {
+    let trusted_titles = trusted_musicbrainz_titles(musicbrainz_releases);
+    diagnostic.push_str(&format!(
+        "MusicBrainz trusted titles: [{}]\n",
+        trusted_titles.join(", ")
+    ));
+    let compatible_musicbrainz_metadata = musicbrainz_releases
+        .iter()
+        .filter(|release| release.media_track_counts.contains(&hints.track_count))
+        .map(metadata_completeness)
+        .max();
+    let Some(default_metadata_completeness) = compatible_musicbrainz_metadata else {
+        diagnostic.push_str(
+            "MusicBrainz trusted decision: no MusicBrainz release has compatible track count\n",
+        );
+        return None;
+    };
+
+    let mut candidates = Vec::new();
+    diagnostic.push_str("MusicBrainz trusted widened Lidarr album candidates:\n");
+    for album in albums {
+        let normalized_album = normalize_match_text(&album.title);
+        let title_match = trusted_titles
+            .iter()
+            .any(|trusted_title| titles_strongly_match(trusted_title, &normalized_album));
+        let release_year = album.release_date.as_deref().and_then(first_year);
+        let year_match = hints
+            .year
+            .zip(release_year)
+            .is_some_and(|(hint_year, album_year)| hint_year == album_year);
+        let matching_releases = matching_releases(album, hints.track_count);
+        diagnostic.push_str(&format!(
+            "  - album_id={} title={} normalized={} release_date={} title_match={} year_match={} matching_releases={}\n",
+            album.id,
+            album.title,
+            normalized_album,
+            album.release_date.as_deref().unwrap_or("-"),
+            title_match,
+            year_match,
+            matching_releases.len()
+        ));
+        for release in &matching_releases {
+            diagnostic.push_str(&format!(
+                "      release_id={} foreign_release_id={} title={} track_count={} monitored={} format={}\n",
+                release.id,
+                release.foreign_release_id.as_deref().unwrap_or("-"),
+                release.title.as_deref().unwrap_or("-"),
+                release.track_count,
+                release.monitored,
+                release.format.as_deref().unwrap_or("-")
+            ));
+        }
+        if !title_match {
+            continue;
+        }
+
+        for release in matching_releases {
+            let Some(foreign_release_id) = release.foreign_release_id.as_deref() else {
+                continue;
+            };
+            let matching_musicbrainz_release = musicbrainz_releases
+                .iter()
+                .find(|candidate| candidate.id.eq_ignore_ascii_case(foreign_release_id));
+            let metadata_completeness = matching_musicbrainz_release
+                .map(metadata_completeness)
+                .unwrap_or(default_metadata_completeness);
+            let ranked = ranked_musicbrainz_candidate(
+                release,
+                foreign_release_id,
+                matching_musicbrainz_release.is_some(),
+                metadata_completeness,
+            )?;
+            candidates.push(RankedTrustedMusicBrainzRelease { album, ranked });
+        }
+    }
+
+    diagnostic.push_str(&format!(
+        "MusicBrainz trusted candidate count: {}\n",
+        candidates.len()
+    ));
+    for candidate in &candidates {
+        diagnostic.push_str(&format!(
+            "MusicBrainz trusted candidate album_id={} album_title={} ",
+            candidate.album.id, candidate.album.title
+        ));
+        append_musicbrainz_score_diagnostic(diagnostic, &candidate.ranked);
+    }
+
+    let Some(best_index) = best_unique_trusted_musicbrainz_candidate_index(&candidates) else {
+        if candidates.is_empty() {
+            diagnostic.push_str(
+                "MusicBrainz trusted decision: no compatible widened Lidarr release, falling through to GnuDB\n",
+            );
+        } else {
+            diagnostic.push_str(
+                "MusicBrainz trusted decision: ranked candidates tied, falling through to GnuDB\n",
+            );
+        }
+        return None;
+    };
+    let best = &candidates[best_index];
+    diagnostic.push_str(&format!(
+        "MusicBrainz trusted decision: widened album/release selected album_id={} album_title={} foreign_release_id={} release_id={}\n",
+        best.album.id,
+        best.album.title,
+        best.ranked.foreign_release_id,
+        best.ranked.release.id
+    ));
+    Some(FallbackAlbumMatch {
+        album: best.album,
+        release: best.ranked.release,
+    })
+}
+
+fn select_ranked_musicbrainz_release<'a>(
+    lidarr_releases: &[&'a LidarrAlbumRelease],
+    hints: &AlbumMatchHints,
+    musicbrainz_releases: &[MusicBrainzDiscRelease],
+    exact_matches: Vec<(&MusicBrainzDiscRelease, &'a LidarrAlbumRelease)>,
+    diagnostic: &mut String,
+) -> std::result::Result<Option<&'a LidarrAlbumRelease>, String> {
+    let candidates = if exact_matches.is_empty() {
+        ranked_best_effort_musicbrainz_candidates(lidarr_releases, hints, musicbrainz_releases)
+    } else {
+        exact_matches
+            .into_iter()
+            .filter_map(|(musicbrainz_release, lidarr_release)| {
+                ranked_musicbrainz_candidate(
+                    lidarr_release,
+                    &musicbrainz_release.id,
+                    true,
+                    metadata_completeness(musicbrainz_release),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+
+    diagnostic.push_str(&format!(
+        "MusicBrainz best-effort candidate count: {}\n",
+        candidates.len()
+    ));
+    for candidate in &candidates {
+        append_musicbrainz_score_diagnostic(diagnostic, candidate);
+    }
+
+    let Some(best_index) = best_unique_musicbrainz_candidate_index(&candidates) else {
+        if candidates.is_empty() {
+            diagnostic.push_str(
+                "MusicBrainz decision: no compatible Lidarr release, falling through to GnuDB\n",
+            );
+        } else {
+            diagnostic.push_str(
+                "MusicBrainz decision: ranked candidates tied, falling through to GnuDB\n",
+            );
+        }
+        return Ok(None);
+    };
+    let best = &candidates[best_index];
+
+    let decision = if best.score.exact_mbid {
+        "ranked exact MBID selected"
+    } else {
+        "best-effort compatible release selected"
+    };
+    diagnostic.push_str(&format!(
+        "MusicBrainz decision: {decision} foreign_release_id={} release_id={}\n",
+        best.foreign_release_id, best.release.id
+    ));
+    Ok(Some(best.release))
+}
+
+fn ranked_best_effort_musicbrainz_candidates<'a>(
+    lidarr_releases: &[&'a LidarrAlbumRelease],
+    hints: &AlbumMatchHints,
+    musicbrainz_releases: &[MusicBrainzDiscRelease],
+) -> Vec<RankedMusicBrainzRelease<'a>> {
+    let compatible_musicbrainz_metadata = musicbrainz_releases
+        .iter()
+        .filter(|release| release.media_track_counts.contains(&hints.track_count))
+        .map(metadata_completeness)
+        .max();
+    let Some(metadata_completeness) = compatible_musicbrainz_metadata else {
+        return Vec::new();
+    };
+
+    lidarr_releases
+        .iter()
+        .filter(|release| release.track_count == hints.track_count)
+        .filter_map(|release| {
+            ranked_musicbrainz_candidate(
+                release,
+                release.foreign_release_id.as_deref()?,
+                false,
+                metadata_completeness,
+            )
+        })
+        .collect()
+}
+
+fn ranked_musicbrainz_candidate<'a>(
+    release: &'a LidarrAlbumRelease,
+    foreign_release_id: &str,
+    exact_mbid: bool,
+    metadata_completeness: i32,
+) -> Option<RankedMusicBrainzRelease<'a>> {
+    Some(RankedMusicBrainzRelease {
+        release,
+        foreign_release_id: foreign_release_id.to_owned(),
+        score: MusicBrainzReleaseScore {
+            exact_mbid,
+            monitored: release.monitored,
+            track_count_compatible: true,
+            format_preference: release_format_preference(release.format.as_deref()),
+            metadata_completeness,
+        },
+    })
+}
+
+fn best_unique_musicbrainz_candidate_index(
+    candidates: &[RankedMusicBrainzRelease<'_>],
+) -> Option<usize> {
+    let (best_index, best) = candidates
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, candidate)| candidate.score)?;
+    let tied_best_count = candidates
+        .iter()
+        .filter(|candidate| candidate.score == best.score)
+        .count();
+    (tied_best_count == 1).then_some(best_index)
+}
+
+fn best_unique_trusted_musicbrainz_candidate_index(
+    candidates: &[RankedTrustedMusicBrainzRelease<'_>],
+) -> Option<usize> {
+    let (best_index, best) = candidates
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, candidate)| candidate.ranked.score)?;
+    let tied_best_count = candidates
+        .iter()
+        .filter(|candidate| candidate.ranked.score == best.ranked.score)
+        .count();
+    (tied_best_count == 1).then_some(best_index)
+}
+
+fn trusted_musicbrainz_titles(musicbrainz_releases: &[MusicBrainzDiscRelease]) -> Vec<String> {
+    let mut titles = Vec::new();
+    for release in musicbrainz_releases {
+        for title in [
+            release.title.as_deref(),
+            release.release_group_title.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let normalized = normalize_match_text(title);
+            if !normalized.is_empty() && !titles.contains(&normalized) {
+                titles.push(normalized);
+            }
+        }
+    }
+    titles
+}
+
+fn append_musicbrainz_score_diagnostic(
+    diagnostic: &mut String,
+    candidate: &RankedMusicBrainzRelease<'_>,
+) {
+    diagnostic.push_str(&format!(
+        "MusicBrainz ranked Lidarr candidate: release_id={} foreign_release_id={} exact_mbid={} monitored={} track_count_compatible={} format_preference={} metadata_completeness={} title={} track_count={} format={}\n",
+        candidate.release.id,
+        candidate.foreign_release_id,
+        candidate.score.exact_mbid,
+        candidate.score.monitored,
+        candidate.score.track_count_compatible,
+        candidate.score.format_preference,
+        candidate.score.metadata_completeness,
+        candidate.release.title.as_deref().unwrap_or("-"),
+        candidate.release.track_count,
+        candidate.release.format.as_deref().unwrap_or("-")
+    ));
+}
+
+fn metadata_completeness(release: &MusicBrainzDiscRelease) -> i32 {
+    i32::from(release.barcode.is_some())
+        + i32::from(release.date.is_some())
+        + i32::from(release.country.is_some())
+        + i32::from(release.status.is_some())
+        + i32::from(release.quality.is_some())
+        + i32::from(release.label_count > 0)
+        + i32::from(release.media_count > 0)
+        + i32::from(!release.media_formats.is_empty())
+        + i32::from(!release.media_track_counts.is_empty())
+        + i32::from(release.release_group_id.is_some())
+        + i32::from(release.release_group_title.is_some())
+        + i32::from(release.release_group_first_release_date.is_some())
+}
+
+fn release_format_preference(format: Option<&str>) -> i32 {
+    let Some(format) = format.map(|format| format.to_ascii_lowercase()) else {
+        return 0;
+    };
+    if format.contains("cd")
+        || format.contains("digital")
+        || format.contains("download")
+        || format.contains("web")
+    {
+        2
+    } else if format.contains("vinyl")
+        || format.contains("7\"")
+        || format.contains("12\"")
+        || format.contains("cassette")
+    {
+        0
+    } else {
+        1
     }
 }
 
@@ -269,7 +1781,7 @@ struct ManualImportResource {
     indexer_flags: i64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ManualImportArtist {
     id: i64,
@@ -289,6 +1801,81 @@ struct ManualImportAlbum {
 #[serde(rename_all = "camelCase")]
 struct ManualImportTrack {
     id: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LidarrAlbumResource {
+    #[serde(default)]
+    id: i64,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    artist_id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    artist: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    foreign_album_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    release_date: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    monitored: Option<bool>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    releases: Vec<LidarrAlbumRelease>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    add_options: Option<LidarrAddAlbumOptions>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LidarrAlbumRelease {
+    id: i64,
+    #[serde(default)]
+    album_id: i64,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    track_count: usize,
+    #[serde(default)]
+    monitored: bool,
+    #[serde(default)]
+    foreign_release_id: Option<String>,
+    #[serde(default)]
+    country: Vec<String>,
+    #[serde(default)]
+    label: Vec<String>,
+    #[serde(default)]
+    format: Option<String>,
+    #[serde(default)]
+    duration: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LidarrAddAlbumOptions {
+    add_type: String,
+    search_for_new_album: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LidarrSearchResource {
+    #[serde(default)]
+    album: Option<LidarrAlbumResource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LidarrTrackResource {
+    id: i64,
+    #[serde(default)]
+    album_id: i64,
+    #[serde(default)]
+    absolute_track_number: i64,
+    #[serde(default)]
+    track_number: Option<String>,
+    #[serde(default)]
+    title: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -314,10 +1901,47 @@ struct ManualImportFile {
     disable_release_switching: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LidarrCommandResource {
+    #[serde(default)]
+    id: i64,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    command_name: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    result: Option<String>,
+    #[serde(default)]
+    exception: Option<String>,
+}
+
+impl LidarrCommandResource {
+    fn positive_id(&self) -> Option<i64> {
+        (self.id > 0).then_some(self.id)
+    }
+}
+
+enum ManualImportSelection {
+    Selected {
+        files: Vec<ManualImportFile>,
+        diagnostic: String,
+    },
+    Skipped {
+        reason: String,
+        diagnostic: String,
+    },
+}
+
 fn select_manual_import_files(
     request: &ManualImportRequest,
-    candidates: Vec<ManualImportResource>,
-) -> Result<Option<Vec<ManualImportFile>>> {
+    candidates: &[ManualImportResource],
+) -> ManualImportSelection {
+    let mut diagnostic = manual_import_diagnostic_header(request, candidates);
     let mut selected = Vec::with_capacity(request.generated_tracks.len());
 
     for generated_track in &request.generated_tracks {
@@ -325,43 +1949,229 @@ fn select_manual_import_files(
             .iter()
             .filter(|candidate| paths_match(&candidate.path, generated_track))
             .collect::<Vec<_>>();
+        diagnostic.push_str(&format!(
+            "Match check: {} matched {} candidate(s)\n",
+            generated_track.display(),
+            matches.len()
+        ));
         if matches.len() != 1 {
-            return Ok(None);
+            return skipped_selection(
+                "each generated track must match exactly one Lidarr candidate",
+                diagnostic,
+            );
         }
 
-        let Some(file) = manual_import_file(&request.download.download_id, matches[0]) else {
-            return Ok(None);
+        let file = match manual_import_file(&request.download.download_id, matches[0]) {
+            Ok(file) => file,
+            Err(reason) => return skipped_selection(reason, diagnostic),
         };
         selected.push(file);
     }
 
-    if selected.is_empty() || !one_album_release(&selected) {
-        return Ok(None);
+    if selected.is_empty() {
+        return skipped_selection("no generated tracks were selected for import", diagnostic);
     }
-    if !cue_hints_match(request, &candidates, &selected) {
-        return Ok(None);
+    if !one_album_release(&selected) {
+        diagnostic.push_str(
+            "Album release check: selected files did not agree on one artist/album/release\n",
+        );
+        return skipped_selection(
+            "selected tracks must resolve to one album release",
+            diagnostic,
+        );
+    }
+    if !cue_hints_match(request, candidates, &selected) {
+        diagnostic.push_str(
+            "Cue hint check: Lidarr candidate album did not match CUE album hint or track count\n",
+        );
+        return skipped_selection("CUE hints did not match Lidarr candidates", diagnostic);
     }
 
-    Ok(Some(selected))
+    diagnostic.push_str(&format!(
+        "Decision: selected {} track(s) for Lidarr manual import\n",
+        selected.len()
+    ));
+    ManualImportSelection::Selected {
+        files: selected,
+        diagnostic,
+    }
+}
+
+fn skipped_selection(reason: impl Into<String>, mut diagnostic: String) -> ManualImportSelection {
+    let reason = reason.into();
+    diagnostic.push_str(&format!("Decision: skipped manual import: {reason}\n"));
+    ManualImportSelection::Skipped { reason, diagnostic }
+}
+
+enum CommandOutcome {
+    Running,
+    Successful,
+    Failed(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CommandWaitOutcome {
+    Completed,
+    NotCompleted,
+}
+
+fn lidarr_command_outcome(command: &LidarrCommandResource) -> CommandOutcome {
+    if command
+        .result
+        .as_deref()
+        .is_some_and(|result| result.eq_ignore_ascii_case("unsuccessful"))
+    {
+        return CommandOutcome::Failed(lidarr_command_failure_reason(command));
+    }
+
+    match command
+        .status
+        .as_deref()
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("completed") => CommandOutcome::Successful,
+        Some("failed" | "aborted" | "cancelled" | "orphaned") => {
+            CommandOutcome::Failed(lidarr_command_failure_reason(command))
+        }
+        _ => CommandOutcome::Running,
+    }
+}
+
+fn lidarr_command_failure_reason(command: &LidarrCommandResource) -> String {
+    command
+        .exception
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            command
+                .message
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .unwrap_or("command did not report a failure reason")
+        .to_owned()
+}
+
+fn append_lidarr_command_diagnostic(
+    diagnostic: &mut String,
+    label: &str,
+    command: &LidarrCommandResource,
+) {
+    diagnostic.push_str(&format!(
+        "{label}: id={} name={} command_name={} status={} result={} message={} exception={}\n",
+        command.id,
+        command.name.as_deref().unwrap_or("-"),
+        command.command_name.as_deref().unwrap_or("-"),
+        command.status.as_deref().unwrap_or("-"),
+        command.result.as_deref().unwrap_or("-"),
+        command.message.as_deref().unwrap_or("-"),
+        command.exception.as_deref().unwrap_or("-")
+    ));
+}
+
+fn append_lidarr_manual_import_command_files(diagnostic: &mut String, files: &[ManualImportFile]) {
+    diagnostic.push_str("Lidarr manual import command files:\n");
+    for file in files {
+        diagnostic.push_str(&format!(
+            "  - path={} artist_id={} album_id={} album_release_id={} track_ids={:?} quality={} indexer_flags={} download_id={} disable_release_switching={}\n",
+            file.path,
+            file.artist_id,
+            file.album_id,
+            file.album_release_id,
+            file.track_ids,
+            quality_summary(&file.quality),
+            file.indexer_flags,
+            file.download_id,
+            file.disable_release_switching
+        ));
+    }
+}
+
+fn quality_summary(quality: &Value) -> String {
+    let quality_value = quality.get("quality").unwrap_or(quality);
+    let id = quality_value
+        .get("id")
+        .and_then(Value::as_i64)
+        .map_or_else(|| "-".to_owned(), |id| id.to_string());
+    let name = quality_value
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    format!("id={id} name={name}")
+}
+
+async fn verify_manual_import_source_files_moved(
+    files: &[ManualImportFile],
+    diagnostic: &mut String,
+) -> Result<()> {
+    let submitted_paths = files
+        .iter()
+        .map(|file| file.path.clone())
+        .collect::<Vec<_>>();
+    let remaining_paths = tokio::task::spawn_blocking(move || {
+        submitted_paths
+            .into_iter()
+            .filter(|path| Path::new(path).exists())
+            .collect::<Vec<_>>()
+    })
+    .await
+    .map_err(|err| anyhow!("blocking source verification task failed to join: {err}"))?;
+
+    diagnostic.push_str(&format!(
+        "Lidarr manual import source verification: submitted={} remaining_at_source={}\n",
+        files.len(),
+        remaining_paths.len()
+    ));
+    for path in &remaining_paths {
+        diagnostic.push_str(&format!("  - remaining source: {path}\n"));
+    }
+
+    if remaining_paths.is_empty() {
+        diagnostic.push_str(
+            "Lidarr manual import source verification: all submitted source files were moved or removed\n",
+        );
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "lidarr manual import command reported success, but {} of {} submitted source files still exist at source\n{diagnostic}",
+        remaining_paths.len(),
+        files.len()
+    ))
 }
 
 fn paths_match(candidate_path: &str, generated_track: &Path) -> bool {
     Path::new(candidate_path) == generated_track
 }
 
-fn manual_import_file(download_id: &str, item: &ManualImportResource) -> Option<ManualImportFile> {
-    let artist_id = item.artist.as_ref()?.id;
-    let album_id = item.album.as_ref()?.id;
+fn manual_import_file(
+    download_id: &str,
+    item: &ManualImportResource,
+) -> std::result::Result<ManualImportFile, String> {
+    let artist_id = item
+        .artist
+        .as_ref()
+        .map(|artist| artist.id)
+        .ok_or_else(|| format!("{} is missing artist", item.path))?;
+    let album_id = item
+        .album
+        .as_ref()
+        .map(|album| album.id)
+        .ok_or_else(|| format!("{} is missing album", item.path))?;
     if item.album_release_id <= 0 {
-        return None;
+        return Err(format!("{} is missing album release", item.path));
     }
-    let quality = item.quality.clone()?;
+    let quality = item
+        .quality
+        .clone()
+        .ok_or_else(|| format!("{} is missing quality", item.path))?;
     let track_ids = item.tracks.iter().map(|track| track.id).collect::<Vec<_>>();
     if track_ids.is_empty() {
-        return None;
+        return Err(format!("{} is missing tracks", item.path));
     }
 
-    Some(ManualImportFile {
+    Ok(ManualImportFile {
         path: item.path.clone(),
         artist_id,
         album_id,
@@ -372,6 +2182,70 @@ fn manual_import_file(download_id: &str, item: &ManualImportResource) -> Option<
         download_id: download_id.to_owned(),
         disable_release_switching: false,
     })
+}
+
+fn manual_import_diagnostic_header(
+    request: &ManualImportRequest,
+    candidates: &[ManualImportResource],
+) -> String {
+    let mut diagnostic = String::new();
+    diagnostic.push_str("Manual import diagnostic\n");
+    diagnostic.push_str("Generated split tracks:\n");
+    for track in &request.generated_tracks {
+        diagnostic.push_str(&format!("  - {}\n", track.display()));
+    }
+    diagnostic.push_str("CUE hints:\n");
+    for hint in &request.cue_hints {
+        diagnostic.push_str(&format!(
+            "  - path={} album={} performer={} catalog={} track_count={}\n",
+            hint.path.display(),
+            hint.album_title.as_deref().unwrap_or("-"),
+            hint.performer.as_deref().unwrap_or("-"),
+            hint.catalog.as_deref().unwrap_or("-"),
+            hint.track_count
+        ));
+        for (key, value) in &hint.comments {
+            diagnostic.push_str(&format!("    REM {key} {value}\n"));
+        }
+    }
+    diagnostic.push_str("Lidarr manual import candidates:\n");
+    for candidate in candidates {
+        let track_ids = candidate
+            .tracks
+            .iter()
+            .map(|track| track.id.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        diagnostic.push_str(&format!(
+            "  - path={} artist_id={} artist={} album_id={} album={} album_release_id={} track_ids=[{}] quality_present={} indexer_flags={}\n",
+            candidate.path,
+            candidate
+                .artist
+                .as_ref()
+                .map(|artist| artist.id.to_string())
+                .unwrap_or_else(|| "-".into()),
+            candidate
+                .artist
+                .as_ref()
+                .and_then(|artist| artist.artist_name.as_deref())
+                .unwrap_or("-"),
+            candidate
+                .album
+                .as_ref()
+                .map(|album| album.id.to_string())
+                .unwrap_or_else(|| "-".into()),
+            candidate
+                .album
+                .as_ref()
+                .and_then(|album| album.title.as_deref())
+                .unwrap_or("-"),
+            candidate.album_release_id,
+            track_ids,
+            candidate.quality.is_some(),
+            candidate.indexer_flags
+        ));
+    }
+    diagnostic
 }
 
 fn one_album_release(files: &[ManualImportFile]) -> bool {
@@ -430,19 +2304,593 @@ fn normalize_hint(value: &str) -> String {
     value.trim().to_lowercase()
 }
 
+struct FallbackPrerequisites<'a> {
+    artist_id: i64,
+    artist: ManualImportArtist,
+    candidates_by_path: HashMap<String, &'a ManualImportResource>,
+}
+
+fn fallback_prerequisites<'a>(
+    request: &ManualImportRequest,
+    candidates: &'a [ManualImportResource],
+) -> std::result::Result<FallbackPrerequisites<'a>, String> {
+    if request.generated_tracks.is_empty() {
+        return Err("no generated tracks were selected for import".into());
+    }
+
+    let mut artist_id = None;
+    let mut artist = None;
+    let mut candidates_by_path = HashMap::new();
+    let mut saw_missing_lidarr_metadata = false;
+
+    for generated_track in &request.generated_tracks {
+        let matches = candidates
+            .iter()
+            .filter(|candidate| paths_match(&candidate.path, generated_track))
+            .collect::<Vec<_>>();
+        if matches.len() != 1 {
+            return Err("each generated track must match exactly one Lidarr candidate".into());
+        }
+        let candidate = matches[0];
+        let candidate_artist_id = candidate
+            .artist
+            .as_ref()
+            .map(|artist| artist.id)
+            .ok_or_else(|| format!("{} is missing artist", candidate.path))?;
+        let candidate_artist = candidate
+            .artist
+            .as_ref()
+            .expect("candidate artist is present after candidate_artist_id");
+        if candidate.quality.is_none() {
+            return Err(format!("{} is missing quality", candidate.path));
+        }
+        if candidate.album.is_none()
+            || candidate.album_release_id <= 0
+            || candidate.tracks.is_empty()
+        {
+            saw_missing_lidarr_metadata = true;
+        }
+        match artist_id {
+            Some(id) if id != candidate_artist_id => {
+                return Err("fallback candidates must agree on one artist".into());
+            }
+            Some(_) => {}
+            None => {
+                artist_id = Some(candidate_artist_id);
+                artist = Some(candidate_artist.clone());
+            }
+        }
+        candidates_by_path.insert(generated_track.to_string_lossy().to_string(), candidate);
+    }
+
+    if !saw_missing_lidarr_metadata {
+        return Err("direct Lidarr metadata was present; fallback is not applicable".into());
+    }
+
+    Ok(FallbackPrerequisites {
+        artist_id: artist_id.expect("artist_id is set when generated tracks are non-empty"),
+        artist: artist.expect("artist is set when generated tracks are non-empty"),
+        candidates_by_path,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AlbumMatchHints {
+    cue_paths: Vec<PathBuf>,
+    album_title: Option<String>,
+    artist: Option<String>,
+    disc_id: Option<String>,
+    year: Option<i32>,
+    track_count: usize,
+    track_titles_by_number: HashMap<i64, String>,
+}
+
+impl AlbumMatchHints {
+    fn from_request(request: &ManualImportRequest) -> Self {
+        let album_title = request
+            .cue_hints
+            .iter()
+            .filter_map(|hint| hint.album_title.as_deref())
+            .find(|title| !title.trim().is_empty())
+            .map(str::to_owned)
+            .or_else(|| album_title_from_download(&request.download.title))
+            .or_else(|| album_title_from_download(&request.download.output_path));
+        let artist = request
+            .cue_hints
+            .iter()
+            .filter_map(|hint| hint.performer.as_deref())
+            .find(|performer| !performer.trim().is_empty())
+            .map(str::to_owned);
+        let disc_id = request
+            .cue_hints
+            .iter()
+            .filter_map(|hint| hint.disc_id.as_deref())
+            .find(|disc_id| !disc_id.trim().is_empty())
+            .map(|disc_id| disc_id.trim().to_owned());
+        let year = request
+            .cue_hints
+            .iter()
+            .find_map(year_from_cue_hint)
+            .or_else(|| first_year(&request.download.title))
+            .or_else(|| first_year(&request.download.output_path));
+        let track_count = request
+            .cue_hints
+            .iter()
+            .map(|hint| hint.track_count)
+            .sum::<usize>()
+            .max(request.generated_tracks.len());
+        let mut track_titles_by_number = HashMap::new();
+        for hint in &request.cue_hints {
+            for track in &hint.tracks {
+                let Some(number) = parse_track_number(&track.number) else {
+                    continue;
+                };
+                let Some(title) = track
+                    .title
+                    .as_ref()
+                    .filter(|title| !title.trim().is_empty())
+                else {
+                    continue;
+                };
+                track_titles_by_number.insert(number, title.clone());
+            }
+        }
+
+        Self {
+            cue_paths: request
+                .cue_hints
+                .iter()
+                .map(|hint| hint.path.clone())
+                .collect(),
+            album_title,
+            artist,
+            disc_id,
+            year,
+            track_count,
+            track_titles_by_number,
+        }
+    }
+}
+
+fn append_album_match_hints(diagnostic: &mut String, hints: &AlbumMatchHints) {
+    diagnostic.push_str(&format!(
+        "Fallback hints: album={} artist={} year={} track_count={}\n",
+        hints.album_title.as_deref().unwrap_or("-"),
+        hints.artist.as_deref().unwrap_or("-"),
+        hints
+            .year
+            .map(|year| year.to_string())
+            .unwrap_or_else(|| "-".into()),
+        hints.track_count
+    ));
+    diagnostic.push_str(&format!(
+        "Fallback CUE DISCID: {}\n",
+        hints.disc_id.as_deref().unwrap_or("-")
+    ));
+    if !hints.track_titles_by_number.is_empty() {
+        diagnostic.push_str("Fallback CUE tracks:\n");
+        let mut tracks = hints.track_titles_by_number.iter().collect::<Vec<_>>();
+        tracks.sort_by_key(|(number, _)| *number);
+        for (number, title) in tracks {
+            diagnostic.push_str(&format!("  - {number}: {title}\n"));
+        }
+    }
+}
+
+struct FallbackAlbumMatch<'a> {
+    album: &'a LidarrAlbumResource,
+    release: &'a LidarrAlbumRelease,
+}
+
+struct SelectedFallbackAlbum {
+    album_id: i64,
+    album_release_id: i64,
+}
+
+struct FallbackAlbumCandidate<'a> {
+    album: &'a LidarrAlbumResource,
+    releases: Vec<&'a LidarrAlbumRelease>,
+    requires_disc_lookup: bool,
+}
+
+fn select_fallback_album_candidate<'a>(
+    albums: &'a [LidarrAlbumResource],
+    hints: &AlbumMatchHints,
+    diagnostic: &mut String,
+) -> std::result::Result<FallbackAlbumCandidate<'a>, String> {
+    let Some(album_title) = hints.album_title.as_deref() else {
+        return Err("fallback requires an album title hint".into());
+    };
+    let normalized_hint = normalize_match_text(album_title);
+    if normalized_hint.is_empty() {
+        return Err("fallback album title hint normalized to empty text".into());
+    }
+
+    diagnostic.push_str("Fallback album candidates:\n");
+    let mut matches = Vec::new();
+    for album in albums {
+        let normalized_album = normalize_match_text(&album.title);
+        let title_match = titles_strongly_match(&normalized_hint, &normalized_album);
+        let release_year = album.release_date.as_deref().and_then(first_year);
+        let year_match = hints
+            .year
+            .zip(release_year)
+            .is_some_and(|(hint_year, album_year)| hint_year == album_year);
+        let year_compatible = match (hints.year, release_year) {
+            (Some(_), Some(_)) => year_match,
+            (Some(_), None) => false,
+            (None, _) => true,
+        };
+        let releases = matching_releases(album, hints.track_count);
+        let release_candidates = if releases.is_empty() && hints.disc_id.is_some() {
+            album.releases.iter().collect::<Vec<_>>()
+        } else {
+            releases.clone()
+        };
+        let requires_disc_lookup = releases.is_empty();
+        diagnostic.push_str(&format!(
+            "  - album_id={} title={} normalized={} release_date={} title_match={} year_match={} matching_releases={} disc_lookup_release_candidates={}\n",
+            album.id,
+            album.title,
+            normalized_album,
+            album.release_date.as_deref().unwrap_or("-"),
+            title_match,
+            year_match,
+            releases.len(),
+            release_candidates.len()
+        ));
+        for release in &release_candidates {
+            diagnostic.push_str(&format!(
+                "      release_id={} album_id={} foreign_release_id={} title={} track_count={} monitored={}\n",
+                release.id,
+                release.album_id,
+                release.foreign_release_id.as_deref().unwrap_or("-"),
+                release.title.as_deref().unwrap_or("-"),
+                release.track_count,
+                release.monitored
+            ));
+        }
+        if title_match && year_compatible && !release_candidates.is_empty() {
+            matches.push(FallbackAlbumCandidate {
+                album,
+                releases: release_candidates,
+                requires_disc_lookup,
+            });
+        }
+    }
+
+    if matches.is_empty() {
+        return Err("no Lidarr album matched title/year/track-count hints".into());
+    }
+    if matches.len() > 1 {
+        return Err("multiple Lidarr albums matched fallback hints".into());
+    }
+
+    Ok(matches.remove(0))
+}
+
+fn matching_releases(album: &LidarrAlbumResource, track_count: usize) -> Vec<&LidarrAlbumRelease> {
+    album
+        .releases
+        .iter()
+        .filter(|release| release.track_count == track_count)
+        .collect()
+}
+
+fn lidarr_source_artist(albums: &[LidarrAlbumResource], artist_id: i64) -> Option<&Value> {
+    albums
+        .iter()
+        .find(|album| album.artist_id == artist_id)
+        .and_then(|album| album.artist.as_ref())
+        .or_else(|| albums.iter().find_map(|album| album.artist.as_ref()))
+}
+
+fn select_fallback_release(releases: Vec<&LidarrAlbumRelease>) -> Option<&LidarrAlbumRelease> {
+    if releases.len() == 1 {
+        return releases.into_iter().next();
+    }
+    let monitored = releases
+        .iter()
+        .copied()
+        .filter(|release| release.monitored)
+        .collect::<Vec<_>>();
+    if monitored.len() == 1 {
+        return monitored.into_iter().next();
+    }
+    None
+}
+
+fn map_generated_tracks_to_lidarr_tracks(
+    request: &ManualImportRequest,
+    tracks: &[LidarrTrackResource],
+    diagnostic: &mut String,
+) -> std::result::Result<HashMap<String, i64>, String> {
+    let cue_titles = AlbumMatchHints::from_request(request).track_titles_by_number;
+    let mut mapped = HashMap::new();
+    let mut used_track_ids = HashSet::new();
+
+    diagnostic.push_str("Fallback Lidarr tracks:\n");
+    for track in tracks {
+        diagnostic.push_str(&format!(
+            "  - track_id={} album_id={} absolute={} track_number={} title={}\n",
+            track.id,
+            track.album_id,
+            track.absolute_track_number,
+            track.track_number.as_deref().unwrap_or("-"),
+            track.title
+        ));
+    }
+    diagnostic.push_str("Fallback track mapping:\n");
+
+    for generated_track in &request.generated_tracks {
+        let parsed = parse_generated_track(generated_track);
+        let Some(number) = parsed.number else {
+            return Err(format!(
+                "{} did not contain a parseable track number",
+                generated_track.display()
+            ));
+        };
+        let generated_title = cue_titles
+            .get(&number)
+            .cloned()
+            .or(parsed.title)
+            .unwrap_or_default();
+        let normalized_generated = normalize_track_title(&generated_title);
+        let matches = tracks
+            .iter()
+            .filter(|track| lidarr_track_number(track) == Some(number))
+            .filter_map(|track| {
+                let normalized_lidarr = normalize_track_title(&track.title);
+                track_title_match_kind(&normalized_generated, &normalized_lidarr)
+                    .map(|match_kind| (track, normalized_lidarr, match_kind))
+            })
+            .collect::<Vec<_>>();
+
+        diagnostic.push_str(&format!(
+            "  - generated={} number={} title={} normalized={} matches={}\n",
+            generated_track.display(),
+            number,
+            generated_title,
+            normalized_generated,
+            matches.len()
+        ));
+        for (matched, normalized_lidarr, match_kind) in &matches {
+            diagnostic.push_str(&format!(
+                "      matched track_id={} title={} normalized={} match={}\n",
+                matched.id, matched.title, normalized_lidarr, match_kind
+            ));
+        }
+
+        if matches.len() != 1 {
+            return Err(format!(
+                "{} did not map uniquely to a Lidarr track",
+                generated_track.display()
+            ));
+        }
+        let track_id = matches[0].0.id;
+        if !used_track_ids.insert(track_id) {
+            return Err(format!(
+                "Lidarr track {track_id} was matched more than once"
+            ));
+        }
+        mapped.insert(generated_track.to_string_lossy().to_string(), track_id);
+    }
+
+    Ok(mapped)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GeneratedTrackHint {
+    number: Option<i64>,
+    title: Option<String>,
+}
+
+fn parse_generated_track(path: &Path) -> GeneratedTrackHint {
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return GeneratedTrackHint {
+            number: None,
+            title: None,
+        };
+    };
+    let parts = stem
+        .split(" - ")
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    for (index, part) in parts.iter().enumerate().rev() {
+        let Some(number) = parse_track_number(part) else {
+            continue;
+        };
+        let title = parts.get(index + 1..).and_then(|title_parts| {
+            let title = title_parts.join(" - ");
+            (!title.trim().is_empty()).then_some(title)
+        });
+        return GeneratedTrackHint {
+            number: Some(number),
+            title,
+        };
+    }
+
+    GeneratedTrackHint {
+        number: None,
+        title: Some(stem.to_owned()),
+    }
+}
+
+fn lidarr_track_number(track: &LidarrTrackResource) -> Option<i64> {
+    track
+        .track_number
+        .as_deref()
+        .and_then(parse_track_number)
+        .or_else(|| (track.absolute_track_number > 0).then_some(track.absolute_track_number))
+}
+
+fn parse_track_number(value: &str) -> Option<i64> {
+    let digits = value
+        .chars()
+        .skip_while(|ch| !ch.is_ascii_digit())
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse().ok()
+    }
+}
+
+fn year_from_cue_hint(hint: &CueMetadataHint) -> Option<i32> {
+    hint.comments
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case("date"))
+        .and_then(|(_, value)| first_year(value))
+}
+
+fn first_year(value: &str) -> Option<i32> {
+    value
+        .as_bytes()
+        .windows(4)
+        .filter_map(|window| std::str::from_utf8(window).ok())
+        .find_map(|candidate| {
+            let year = candidate.parse::<i32>().ok()?;
+            (1900..=2100).contains(&year).then_some(year)
+        })
+}
+
+fn album_title_from_download(value: &str) -> Option<String> {
+    let stem = Path::new(value)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or(value);
+    let without_year = remove_parenthetical_year(stem);
+    let parts = without_year
+        .split(" - ")
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    parts
+        .last()
+        .map(|part| (*part).to_owned())
+        .filter(|part| !part.is_empty())
+}
+
+fn remove_parenthetical_year(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '(' {
+            let mut fragment = String::new();
+            while let Some(next) = chars.peek().copied() {
+                chars.next();
+                if next == ')' {
+                    break;
+                }
+                fragment.push(next);
+            }
+            if first_year(&fragment).is_some() {
+                continue;
+            }
+            out.push(' ');
+            out.push_str(&fragment);
+            out.push(' ');
+            continue;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn normalize_track_title(value: &str) -> String {
+    normalize_match_text(&remove_parenthetical_year(value))
+}
+
+fn normalize_match_text(value: &str) -> String {
+    let mut normalized = String::with_capacity(value.len());
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_alphanumeric() {
+            normalized.push(ch);
+        } else {
+            normalized.push(' ');
+        }
+    }
+    normalized.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn titles_strongly_match(left: &str, right: &str) -> bool {
+    if left.is_empty() || right.is_empty() {
+        return false;
+    }
+    if left == right {
+        return true;
+    }
+    let left_tokens = significant_tokens(left);
+    let right_tokens = significant_tokens(right);
+    !left_tokens.is_empty()
+        && !right_tokens.is_empty()
+        && (left_tokens.is_subset(&right_tokens) || right_tokens.is_subset(&left_tokens))
+}
+
+fn significant_tokens(value: &str) -> HashSet<String> {
+    value
+        .split_whitespace()
+        .filter(|token| !matches!(*token, "the" | "a" | "an"))
+        .map(str::to_owned)
+        .collect()
+}
+
+fn track_title_match_kind(left: &str, right: &str) -> Option<&'static str> {
+    if left.is_empty() || right.is_empty() {
+        return None;
+    }
+    if left == right {
+        return Some("exact");
+    }
+    if titles_strongly_match(left, right) {
+        return Some("strong");
+    }
+
+    let relaxed_left = relax_dropped_g_suffixes(left);
+    let relaxed_right = relax_dropped_g_suffixes(right);
+    if (relaxed_left != left || relaxed_right != right)
+        && titles_strongly_match(&relaxed_left, &relaxed_right)
+    {
+        return Some("relaxed-dropped-g");
+    }
+
+    None
+}
+
+fn relax_dropped_g_suffixes(value: &str) -> String {
+    value
+        .split_whitespace()
+        .map(|token| {
+            token
+                .strip_suffix("ing")
+                .filter(|stem| stem.len() >= 2)
+                .map_or_else(|| token.to_owned(), |stem| format!("{stem}in"))
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::fs;
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     use serde_json::Value;
+    use tempfile::tempdir;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
     use super::LidarrQueueSource;
     use crate::application::ports::{
-        CueMetadataHint, ManualImportRequest, ManualImportResult, ManualImportTrigger, QueueSource,
+        CueMetadataHint, CueTrackHint, DiscReleaseCandidate, DiscReleaseLookup,
+        DiscReleaseLookupRequest, DiscReleaseLookupResult, ManualImportRequest, ManualImportResult,
+        ManualImportTrigger, MusicBrainzDiscLookupRequest, MusicBrainzDiscLookupResult,
+        MusicBrainzDiscRelease, MusicBrainzDiscReleaseLookup, QueueSource,
     };
     use crate::bootstrap::settings::LidarrSettings;
     use crate::domain::{FailedImportCandidate, TrackedDownload};
@@ -660,12 +3108,17 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            result,
-            ManualImportResult::Started {
-                imported_track_count: 2
-            }
-        );
+        let ManualImportResult::Started {
+            imported_track_count,
+            diagnostic,
+        } = result
+        else {
+            panic!("expected manual import to start");
+        };
+        assert_eq!(imported_track_count, 2);
+        assert!(diagnostic.contains("Generated split tracks"));
+        assert!(diagnostic.contains("album_release_id=3"));
+        assert!(diagnostic.contains("track_ids=[11]"));
         let requests = requests.lock().unwrap();
         assert_eq!(requests.len(), 2);
         assert!(requests[0].starts_with("GET /api/v1/manualimport?"));
@@ -681,6 +3134,104 @@ mod tests {
         assert_eq!(command["files"][0]["albumReleaseId"], 3);
         assert_eq!(command["files"][0]["trackIds"], serde_json::json!([11]));
         assert_eq!(command["files"][0]["downloadId"], "download-1");
+    }
+
+    #[tokio::test]
+    async fn manual_import_polls_started_command_until_completed() {
+        let candidates = r#"[
+            {"path":"/downloads/album/01.flac","artist":{"id":1,"artistName":"Artist"},"album":{"id":2,"title":"Album"},"albumReleaseId":3,"tracks":[{"id":11}],"quality":{"quality":{"id":6,"name":"FLAC"}},"indexerFlags":0}
+        ]"#;
+        let started = r#"{"id":7,"name":"ManualImport","commandName":"Manual Import","status":"started","result":"unknown","message":"Importing"}"#;
+        let completed = r#"{"id":7,"name":"ManualImport","commandName":"Manual Import","status":"completed","result":"successful","message":"Completed"}"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("201 Created", started),
+            ("200 OK", completed),
+        ])
+        .await;
+        let client = lidarr_client(url, true).with_lidarr_command_poll(3, Duration::ZERO);
+
+        let result = client
+            .trigger_manual_import(manual_import_request(vec!["/downloads/album/01.flac"], 1))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started { diagnostic, .. } = result else {
+            panic!("expected manual import to start");
+        };
+        assert!(diagnostic.contains("Lidarr manual import command accepted: id=7"));
+        assert!(diagnostic.contains("Lidarr manual import command poll attempt=1: id=7"));
+        assert!(
+            diagnostic.contains("Lidarr manual import command decision: completed successfully")
+        );
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 3);
+        assert!(requests[2].starts_with("GET /api/v1/command/7 "));
+    }
+
+    #[tokio::test]
+    async fn manual_import_reports_started_command_failure() {
+        let candidates = r#"[
+            {"path":"/downloads/album/01.flac","artist":{"id":1,"artistName":"Artist"},"album":{"id":2,"title":"Album"},"albumReleaseId":3,"tracks":[{"id":11}],"quality":{"quality":{"id":6,"name":"FLAC"}},"indexerFlags":0}
+        ]"#;
+        let started = r#"{"id":7,"name":"ManualImport","commandName":"Manual Import","status":"started","result":"unknown","message":"Importing"}"#;
+        let failed = r#"{"id":7,"name":"ManualImport","commandName":"Manual Import","status":"failed","result":"unsuccessful","message":"Failed","exception":"track import exploded"}"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("201 Created", started),
+            ("200 OK", failed),
+        ])
+        .await;
+        let client = lidarr_client(url, true).with_lidarr_command_poll(3, Duration::ZERO);
+
+        let err = client
+            .trigger_manual_import(manual_import_request(vec!["/downloads/album/01.flac"], 1))
+            .await
+            .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("lidarr manual import command failed"));
+        assert!(message.contains("track import exploded"));
+        assert!(message.contains("Lidarr manual import command poll attempt=1"));
+        assert!(message.contains("track_ids=[11]"));
+        assert_eq!(requests.lock().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn manual_import_reports_completed_command_with_remaining_sources() {
+        let tmp = tempdir().unwrap();
+        let source = tmp.path().join("Artist - Album - 01 - One.flac");
+        fs::write(&source, b"audio").unwrap();
+        let source = source.to_string_lossy().to_string();
+        let candidates = serde_json::json!([
+            {
+                "path": source,
+                "artist": {"id": 1, "artistName": "Artist"},
+                "album": {"id": 2, "title": "Album"},
+                "albumReleaseId": 3,
+                "tracks": [{"id": 11}],
+                "quality": {"quality": {"id": 6, "name": "FLAC"}},
+                "indexerFlags": 0
+            }
+        ])
+        .to_string();
+        let candidates = Box::leak(candidates.into_boxed_str());
+        let completed = r#"{"id":7,"name":"ManualImport","commandName":"Manual Import","status":"completed","result":"successful","message":"Manually imported 1 files"}"#;
+        let (url, requests) =
+            serve_sequence(vec![("200 OK", candidates), ("201 Created", completed)]).await;
+        let client = lidarr_client(url, true).with_lidarr_command_poll(3, Duration::ZERO);
+
+        let err = client
+            .trigger_manual_import(manual_import_request(vec![&source], 1))
+            .await
+            .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("reported success"));
+        assert!(message.contains("still exist at source"));
+        assert!(message.contains("Lidarr manual import source verification"));
+        assert!(message.contains(&source));
+        assert_eq!(requests.lock().unwrap().len(), 2);
     }
 
     #[tokio::test]
@@ -700,7 +3251,13 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(matches!(result, ManualImportResult::Skipped { .. }));
+        let ManualImportResult::Skipped { reason, diagnostic } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(reason.contains("one album release"));
+        assert!(diagnostic.contains("album_release_id=3"));
+        assert!(diagnostic.contains("album_release_id=4"));
+        assert!(diagnostic.contains("Decision: skipped manual import"));
         assert_eq!(requests.lock().unwrap().len(), 1);
     }
 
@@ -717,7 +3274,12 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(matches!(result, ManualImportResult::Skipped { .. }));
+        let ManualImportResult::Skipped { reason, diagnostic } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(reason.contains("missing quality"));
+        assert!(diagnostic.contains("quality_present=false"));
+        assert!(diagnostic.contains("/downloads/album/01.flac"));
         assert_eq!(requests.lock().unwrap().len(), 1);
     }
 
@@ -733,6 +3295,1370 @@ mod tests {
 
         assert!(err.to_string().contains("HTTP 500"));
         assert!(err.to_string().contains("manual import candidates"));
+    }
+
+    #[tokio::test]
+    async fn manual_import_command_errors_include_diagnostic() {
+        let candidates = r#"[
+            {"path":"/downloads/album/01.flac","artist":{"id":1,"artistName":"Artist"},"album":{"id":2,"title":"Album"},"albumReleaseId":3,"tracks":[{"id":11}],"quality":{"quality":{"id":6,"name":"FLAC"}},"indexerFlags":0}
+        ]"#;
+        let (url, _) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("500 Internal Server Error", "boom"),
+        ])
+        .await;
+        let client = lidarr_client(url, true);
+
+        let err = client
+            .trigger_manual_import(manual_import_request(vec!["/downloads/album/01.flac"], 1))
+            .await
+            .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("HTTP 500"));
+        assert!(message.contains("Manual import diagnostic"));
+        assert!(message.contains("track_ids=[11]"));
+    }
+
+    #[test]
+    fn fallback_normalization_tolerates_common_filename_noise() {
+        assert_eq!(
+            super::normalize_match_text("Kalimba_De Luna... (1984)"),
+            "kalimba de luna 1984"
+        );
+        assert_eq!(
+            super::normalize_track_title("The Calendar Song _January_ February_ March_"),
+            "the calendar song january february march"
+        );
+        assert!(super::titles_strongly_match(
+            &super::normalize_track_title("The Calendar Song (January February March)"),
+            &super::normalize_track_title("Calendar Song _January_ February_ March_")
+        ));
+        assert_eq!(
+            super::track_title_match_kind(
+                &super::normalize_track_title("Hold On I'm Coming"),
+                &super::normalize_track_title("Hold On! I\u{2019}m Comin\u{2019}")
+            ),
+            Some("relaxed-dropped-g")
+        );
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_infers_album_release_and_tracks() {
+        let candidates = r#"[
+            {"path":"/downloads/Boney M. - Oceans Of Fantasy(1979)/Boney M. - Oceans Of Fantasy - 01 - Let It All Be Music.flac","artist":{"id":16,"artistName":"Boney M."},"quality":{"quality":{"id":6,"name":"FLAC"}},"indexerFlags":2},
+            {"path":"/downloads/Boney M. - Oceans Of Fantasy(1979)/Boney M. - Oceans Of Fantasy - 02 - Gotta Go Home.flac","artist":{"id":16,"artistName":"Boney M."},"quality":{"quality":{"id":6,"name":"FLAC"}},"indexerFlags":2}
+        ]"#;
+        let albums = r#"[
+            {"id":22,"title":"Oceans Of Fantasy","artistId":16,"releaseDate":"1979-01-01T00:00:00Z","releases":[{"id":33,"albumId":22,"title":"Oceans Of Fantasy","trackCount":2,"monitored":true}]}
+        ]"#;
+        let tracks = r#"[
+            {"id":101,"albumId":22,"absoluteTrackNumber":1,"trackNumber":"1","title":"Let It All Be Music"},
+            {"id":102,"albumId":22,"absoluteTrackNumber":2,"trackNumber":"2","title":"Gotta Go Home"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true);
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata(
+                "Boney M. - Oceans Of Fantasy",
+                "/downloads/Boney M. - Oceans Of Fantasy(1979)",
+                "Oceans Of Fantasy",
+                "Boney M.",
+                "1979",
+                vec![
+                    (
+                        "/downloads/Boney M. - Oceans Of Fantasy(1979)/Boney M. - Oceans Of Fantasy - 01 - Let It All Be Music.flac",
+                        "Let It All Be Music",
+                    ),
+                    (
+                        "/downloads/Boney M. - Oceans Of Fantasy(1979)/Boney M. - Oceans Of Fantasy - 02 - Gotta Go Home.flac",
+                        "Gotta Go Home",
+                    ),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started {
+            imported_track_count,
+            diagnostic,
+        } = result
+        else {
+            panic!("expected manual import to start");
+        };
+        assert_eq!(imported_track_count, 2);
+        assert!(diagnostic.contains("Fallback hints: album=Oceans Of Fantasy"));
+        assert!(diagnostic.contains("Fallback selected album: album_id=22"));
+        assert!(diagnostic.contains("matched track_id=101"));
+        assert!(diagnostic.contains("matched track_id=102"));
+
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 4);
+        assert!(requests[1].starts_with("GET /api/v1/album?"));
+        assert!(requests[1].contains("artistId=16"));
+        assert!(requests[2].starts_with("GET /api/v1/track?"));
+        assert!(requests[2].contains("albumId=22"));
+        let command: Value = serde_json::from_str(request_body(&requests[3])).unwrap();
+        assert_eq!(command["files"][0]["artistId"], 16);
+        assert_eq!(command["files"][0]["albumId"], 22);
+        assert_eq!(command["files"][0]["albumReleaseId"], 33);
+        assert_eq!(command["files"][0]["trackIds"], serde_json::json!([101]));
+        assert_eq!(command["files"][1]["trackIds"], serde_json::json!([102]));
+        assert_eq!(command["files"][0]["indexerFlags"], 2);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_maps_dropped_g_track_title_variant() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - Hold On I'm Coming.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6,"name":"FLAC"}},"indexerFlags":0}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1979-01-01","releases":[{"id":3,"albumId":2,"title":"Album","trackCount":1,"monitored":true}]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":2,"absoluteTrackNumber":1,"trackNumber":"1","title":"Hold On! I\u2019m Comin\u2019"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true);
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1979",
+                vec![(
+                    "/downloads/album/Artist - Album - 01 - Hold On I'm Coming.flac",
+                    "Hold On I'm Coming",
+                )],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started {
+            imported_track_count,
+            diagnostic,
+        } = result
+        else {
+            panic!("expected manual import to start");
+        };
+        assert_eq!(imported_track_count, 1);
+        assert!(diagnostic.contains("match=relaxed-dropped-g"));
+        assert!(diagnostic.contains("matched track_id=11"));
+
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 4);
+        let command: Value = serde_json::from_str(request_body(&requests[3])).unwrap();
+        assert_eq!(command["files"][0]["trackIds"], serde_json::json!([11]));
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_skips_multiple_album_matches() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[{"id":3,"albumId":2,"trackCount":1}]},
+            {"id":4,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[{"id":5,"albumId":4,"trackCount":1}]}
+        ]"#;
+        let (url, requests) =
+            serve_sequence(vec![("200 OK", candidates), ("200 OK", albums)]).await;
+        let client = lidarr_client(url, true);
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                vec![("/downloads/album/Artist - Album - 01 - One.flac", "One")],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Skipped { reason, diagnostic } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(reason.contains("multiple Lidarr albums"));
+        assert!(diagnostic.contains("Fallback album candidates"));
+        assert_eq!(requests.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_skips_non_unique_track_matches() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[{"id":3,"albumId":2,"trackCount":1}]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":2,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"},
+            {"id":12,"albumId":2,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+        ])
+        .await;
+        let client = lidarr_client(url, true);
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                vec![("/downloads/album/Artist - Album - 01 - One.flac", "One")],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Skipped { reason, diagnostic } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(reason.contains("did not map uniquely"));
+        assert!(diagnostic.contains("matches=2"));
+        assert_eq!(requests.lock().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_skips_when_no_release_has_expected_track_count() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[{"id":3,"albumId":2,"trackCount":2}]}
+        ]"#;
+        let (url, requests) =
+            serve_sequence(vec![("200 OK", candidates), ("200 OK", albums)]).await;
+        let client = lidarr_client(url, true);
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                vec![("/downloads/album/Artist - Album - 01 - One.flac", "One")],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Skipped { reason, diagnostic } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(reason.contains("no Lidarr album matched"));
+        assert!(diagnostic.contains("matching_releases=0"));
+        assert_eq!(requests.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_skips_partial_track_mapping() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[{"id":3,"albumId":2,"trackCount":2}]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":2,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"},
+            {"id":12,"albumId":2,"absoluteTrackNumber":2,"trackNumber":"2","title":"Different"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+        ])
+        .await;
+        let client = lidarr_client(url, true);
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                vec![
+                    ("/downloads/album/Artist - Album - 01 - One.flac", "One"),
+                    ("/downloads/album/Artist - Album - 02 - Two.flac", "Two"),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Skipped { reason, diagnostic } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(reason.contains("did not map uniquely"));
+        assert!(diagnostic.contains("title=Two"));
+        assert!(diagnostic.contains("matches=0"));
+        assert_eq!(requests.lock().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_uses_gnudb_artid_to_select_lidarr_release() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":false},
+                {"id":4,"albumId":2,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Album","trackCount":2,"monitored":false}
+            ]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":2,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"},
+            {"id":12,"albumId":2,"absoluteTrackNumber":2,"trackNumber":"2","title":"Two"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true).with_disc_release_lookup(Arc::new(FakeDiscLookup {
+            result: DiscReleaseLookupResult::Found {
+                candidates: vec![DiscReleaseCandidate {
+                    category: "rock".into(),
+                    entry_id: "c60c9d10".into(),
+                    disc_id: "C60C9D10".into(),
+                    artist: Some("Artist".into()),
+                    title: Some("Album".into()),
+                    year: Some(1984),
+                    track_titles: vec!["One".into(), "Two".into()],
+                    art_ids: vec!["bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb".into()],
+                }],
+                diagnostic: "GnuDB accepted candidates: 1\n".into(),
+            },
+        }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![
+                    ("/downloads/album/Artist - Album - 01 - One.flac", "One"),
+                    ("/downloads/album/Artist - Album - 02 - Two.flac", "Two"),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started {
+            imported_track_count,
+            diagnostic,
+        } = result
+        else {
+            panic!("expected manual import to start");
+        };
+        assert_eq!(imported_track_count, 2);
+        assert!(diagnostic.contains("Fallback CUE DISCID: C60C9D10"));
+        assert!(diagnostic
+            .contains("GnuDB selected foreign_release_id=bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
+        let requests = requests.lock().unwrap();
+        let command: Value = serde_json::from_str(request_body(&requests[3])).unwrap();
+        assert_eq!(command["files"][0]["albumReleaseId"], 4);
+        assert_eq!(command["files"][1]["albumReleaseId"], 4);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_prefers_musicbrainz_release_id_before_gnudb() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":false},
+                {"id":4,"albumId":2,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Album","trackCount":2,"monitored":false}
+            ]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":2,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"},
+            {"id":12,"albumId":2,"absoluteTrackNumber":2,"trackNumber":"2","title":"Two"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true)
+            .with_musicbrainz_disc_release_lookup(Arc::new(FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![MusicBrainzDiscRelease {
+                        id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb".into(),
+                        title: Some("Album".into()),
+                        media_count: 1,
+                        media_track_counts: vec![2],
+                        ..MusicBrainzDiscRelease::default()
+                    }],
+                    diagnostic: "MusicBrainz lookup: found 1 release(s)\n".into(),
+                },
+            }))
+            .with_disc_release_lookup(Arc::new(FakeDiscLookup {
+                result: DiscReleaseLookupResult::Found {
+                    candidates: vec![DiscReleaseCandidate {
+                        category: "rock".into(),
+                        entry_id: "c60c9d10".into(),
+                        disc_id: "C60C9D10".into(),
+                        artist: Some("Artist".into()),
+                        title: Some("Album".into()),
+                        year: Some(1984),
+                        track_titles: vec!["One".into(), "Two".into()],
+                        art_ids: vec!["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".into()],
+                    }],
+                    diagnostic: "GnuDB should not be used\n".into(),
+                },
+            }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![
+                    ("/downloads/album/Artist - Album - 01 - One.flac", "One"),
+                    ("/downloads/album/Artist - Album - 02 - Two.flac", "Two"),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started { diagnostic, .. } = result else {
+            panic!("expected manual import to start");
+        };
+        assert!(diagnostic.contains(
+            "MusicBrainz decision: exact single MBID selected foreign_release_id=bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        ));
+        assert!(!diagnostic.contains("GnuDB should not be used"));
+        let command: Value =
+            serde_json::from_str(request_body(&requests.lock().unwrap()[3])).unwrap();
+        assert_eq!(command["files"][0]["albumReleaseId"], 4);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_ranks_multiple_musicbrainz_exact_matches_by_monitored_release()
+    {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":false,"format":"CD"},
+                {"id":4,"albumId":2,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Album","trackCount":2,"monitored":true,"format":"CD"}
+            ]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":2,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"},
+            {"id":12,"albumId":2,"absoluteTrackNumber":2,"trackNumber":"2","title":"Two"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true)
+            .with_musicbrainz_disc_release_lookup(Arc::new(FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![
+                        musicbrainz_release("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 2),
+                        musicbrainz_release("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", 2),
+                    ],
+                    diagnostic: "MusicBrainz lookup: found 2 release(s)\n".into(),
+                },
+            }))
+            .with_disc_release_lookup(Arc::new(FakeDiscLookup {
+                result: DiscReleaseLookupResult::NotFound {
+                    diagnostic: "GnuDB should not be used\n".into(),
+                },
+            }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![
+                    ("/downloads/album/Artist - Album - 01 - One.flac", "One"),
+                    ("/downloads/album/Artist - Album - 02 - Two.flac", "Two"),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started { diagnostic, .. } = result else {
+            panic!("expected manual import to start");
+        };
+        assert!(diagnostic.contains("MusicBrainz exact intersection count: 2"));
+        assert!(diagnostic.contains("MusicBrainz decision: ranked exact MBID selected"));
+        assert!(diagnostic.contains("monitored=true"));
+        assert!(!diagnostic.contains("GnuDB should not be used"));
+        let command: Value =
+            serde_json::from_str(request_body(&requests.lock().unwrap()[3])).unwrap();
+        assert_eq!(command["files"][0]["albumReleaseId"], 4);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_best_effort_musicbrainz_selects_monitored_compatible_release() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":false,"format":"CD"},
+                {"id":4,"albumId":2,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Album","trackCount":2,"monitored":true,"format":"CD"}
+            ]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":2,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"},
+            {"id":12,"albumId":2,"absoluteTrackNumber":2,"trackNumber":"2","title":"Two"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true)
+            .with_musicbrainz_disc_release_lookup(Arc::new(FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![musicbrainz_release(
+                        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                        2,
+                    )],
+                    diagnostic: "MusicBrainz lookup: found 1 release(s)\n".into(),
+                },
+            }))
+            .with_disc_release_lookup(Arc::new(FakeDiscLookup {
+                result: DiscReleaseLookupResult::NotFound {
+                    diagnostic: "GnuDB should not be used\n".into(),
+                },
+            }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![
+                    ("/downloads/album/Artist - Album - 01 - One.flac", "One"),
+                    ("/downloads/album/Artist - Album - 02 - Two.flac", "Two"),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started { diagnostic, .. } = result else {
+            panic!("expected manual import to start");
+        };
+        assert!(diagnostic.contains("MusicBrainz exact intersection count: 0"));
+        assert!(
+            diagnostic.contains("MusicBrainz decision: best-effort compatible release selected")
+        );
+        assert!(!diagnostic.contains("GnuDB should not be used"));
+        let command: Value =
+            serde_json::from_str(request_body(&requests.lock().unwrap()[3])).unwrap();
+        assert_eq!(command["files"][0]["albumReleaseId"], 4);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_musicbrainz_skips_when_lidarr_releases_have_wrong_track_count()
+    {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":true,"format":"CD"},
+                {"id":4,"albumId":2,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Album","trackCount":2,"monitored":false,"format":"CD"}
+            ]}
+        ]"#;
+        let (url, requests) =
+            serve_sequence(vec![("200 OK", candidates), ("200 OK", albums)]).await;
+        let client = lidarr_client(url, true)
+            .with_musicbrainz_disc_release_lookup(Arc::new(FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![musicbrainz_release(
+                        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                        16,
+                    )],
+                    diagnostic: "MusicBrainz lookup: found 1 release(s)\n".into(),
+                },
+            }))
+            .with_disc_release_lookup(Arc::new(FakeDiscLookup {
+                result: DiscReleaseLookupResult::NotFound {
+                    diagnostic: "GnuDB lookup: no search candidates\n".into(),
+                },
+            }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![("/downloads/album/Artist - Album - 01 - One.flac", "One")],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Skipped { diagnostic, .. } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(diagnostic.contains("MusicBrainz exact intersection count: 0"));
+        assert!(diagnostic.contains("MusicBrainz best-effort candidate count: 0"));
+        assert!(diagnostic.contains(
+            "MusicBrainz decision: no compatible Lidarr release, falling through to GnuDB"
+        ));
+        assert!(diagnostic.contains("Fallback MusicBrainz add missing release group: false"));
+        assert_eq!(requests.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_adds_missing_musicbrainz_release_group_and_imports() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let initial_albums = "[]";
+        let search = r#"[
+            {"album":{"id":0,"title":"Album","foreignAlbumId":"11111111-1111-1111-1111-111111111111","releases":[]}}
+        ]"#;
+        let added_album =
+            r#"{"id":4,"title":"Album","foreignAlbumId":"11111111-1111-1111-1111-111111111111"}"#;
+        let refetched_albums = r#"[
+            {"id":4,"title":"Album","artistId":1,"foreignAlbumId":"11111111-1111-1111-1111-111111111111","releaseDate":"1984-01-01","releases":[
+                {"id":5,"albumId":4,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":false,"format":"CD"}
+            ]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":4,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"},
+            {"id":12,"albumId":4,"absoluteTrackNumber":2,"trackNumber":"2","title":"Two"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", initial_albums),
+            ("200 OK", search),
+            ("201 Created", added_album),
+            ("200 OK", refetched_albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true)
+            .with_musicbrainz_add_missing_release_group(true)
+            .with_musicbrainz_add_album_refetch(1, Duration::ZERO)
+            .with_musicbrainz_disc_release_lookup(Arc::new(FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![musicbrainz_release(
+                        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                        2,
+                    )],
+                    diagnostic: "MusicBrainz lookup: found 1 release(s)\n".into(),
+                },
+            }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![
+                    ("/downloads/album/Artist - Album - 01 - One.flac", "One"),
+                    ("/downloads/album/Artist - Album - 02 - Two.flac", "Two"),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started { diagnostic, .. } = result else {
+            panic!("expected manual import to start");
+        };
+        assert!(diagnostic.contains("Fallback MusicBrainz add missing release group: true"));
+        assert!(diagnostic.contains(
+            "MusicBrainz add missing release group distinct release_group_ids=[11111111-1111-1111-1111-111111111111]"
+        ));
+        assert!(diagnostic.contains(
+            "MusicBrainz add missing release group decision: Lidarr search album accepted"
+        ));
+        assert!(diagnostic.contains(
+            "MusicBrainz add missing release group decision: added release-group selected"
+        ));
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 7);
+        assert!(requests[2].starts_with("GET /api/v1/search?"));
+        assert!(requests[2].contains("lidarr%3A11111111-1111-1111-1111-111111111111"));
+        assert!(requests[3].starts_with("POST /api/v1/album "));
+        let add_album: Value = serde_json::from_str(request_body(&requests[3])).unwrap();
+        assert_eq!(add_album["artistId"], 1);
+        assert_eq!(add_album["artist"]["id"], 1);
+        assert_eq!(add_album["artist"]["artistName"], "Artist");
+        assert_eq!(add_album["monitored"], false);
+        assert_eq!(add_album["addOptions"]["addType"], "manual");
+        assert_eq!(add_album["addOptions"]["searchForNewAlbum"], false);
+        assert!(requests[4].contains("artistId=1"));
+        assert!(requests[5].contains("albumId=4"));
+        let command: Value = serde_json::from_str(request_body(&requests[6])).unwrap();
+        assert_eq!(command["files"][0]["albumId"], 4);
+        assert_eq!(command["files"][0]["albumReleaseId"], 5);
+        assert_eq!(command["files"][0]["trackIds"], serde_json::json!([11]));
+        assert_eq!(command["files"][1]["trackIds"], serde_json::json!([12]));
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_adds_missing_musicbrainz_release_group_before_gnudb() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 03 - Three.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let initial_albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"artist":{"id":1,"artistName":"Artist","foreignArtistId":"artist-mbid","qualityProfileId":7,"metadataProfileId":3,"rootFolderPath":"/music"},"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":true,"format":"7\" Vinyl"},
+                {"id":4,"albumId":2,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Album","trackCount":2,"monitored":false,"format":"12\" Vinyl"}
+            ]}
+        ]"#;
+        let search = r#"[
+            {"album":{"id":0,"title":"Album: 3 Happy Songs","foreignAlbumId":"11111111-1111-1111-1111-111111111111","releases":[
+                {"id":99,"albumId":0,"foreignReleaseId":"cccccccc-cccc-cccc-cccc-cccccccccccc","title":"Album: 3 Happy Songs","trackCount":3,"monitored":false,"format":"CD","media":[{"mediumNumber":1}]}
+            ]}}
+        ]"#;
+        let added_album = r#"{"id":6,"title":"Album: 3 Happy Songs","foreignAlbumId":"11111111-1111-1111-1111-111111111111"}"#;
+        let refetched_albums_without_releases = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":true,"format":"7\" Vinyl"}
+            ]},
+            {"id":6,"title":"Album: 3 Happy Songs","artistId":1,"foreignAlbumId":"11111111-1111-1111-1111-111111111111","releaseDate":"1984-01-01","releases":[]}
+        ]"#;
+        let refetched_albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":true,"format":"7\" Vinyl"}
+            ]},
+            {"id":6,"title":"Album: 3 Happy Songs","artistId":1,"foreignAlbumId":"11111111-1111-1111-1111-111111111111","releaseDate":"1984-01-01","releases":[
+                {"id":7,"albumId":6,"foreignReleaseId":"cccccccc-cccc-cccc-cccc-cccccccccccc","title":"Album: 3 Happy Songs","trackCount":3,"monitored":false,"format":"CD"}
+            ]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":6,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"},
+            {"id":12,"albumId":6,"absoluteTrackNumber":2,"trackNumber":"2","title":"Two"},
+            {"id":13,"albumId":6,"absoluteTrackNumber":3,"trackNumber":"3","title":"Three"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", initial_albums),
+            ("200 OK", search),
+            ("201 Created", added_album),
+            ("200 OK", refetched_albums_without_releases),
+            ("200 OK", refetched_albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true)
+            .with_musicbrainz_add_missing_release_group(true)
+            .with_musicbrainz_add_album_refetch(5, Duration::ZERO)
+            .with_musicbrainz_disc_release_lookup(Arc::new(FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![musicbrainz_release_with_title(
+                        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                        "Album: 3 Happy Songs",
+                        3,
+                    )],
+                    diagnostic: "MusicBrainz lookup: found 1 release(s)\n".into(),
+                },
+            }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![
+                    ("/downloads/album/Artist - Album - 01 - One.flac", "One"),
+                    ("/downloads/album/Artist - Album - 02 - Two.flac", "Two"),
+                    ("/downloads/album/Artist - Album - 03 - Three.flac", "Three"),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started { diagnostic, .. } = result else {
+            panic!("expected manual import to start");
+        };
+        assert!(diagnostic.contains("MusicBrainz best-effort candidate count: 0"));
+        assert!(diagnostic.contains("Fallback MusicBrainz add missing release group: true"));
+        assert!(diagnostic
+            .contains("MusicBrainz add missing release group search: path=/api/v1/search"));
+        assert!(
+            !diagnostic.contains("Fallback GnuDB release lookup: evaluating"),
+            "{diagnostic}"
+        );
+        assert!(diagnostic.contains(
+            "prepared Lidarr add album payload artist_source=lidarr-album stripped_search_releases=1"
+        ));
+        assert!(diagnostic
+            .contains("MusicBrainz add missing release group refetch attempt=1: album_id=6"));
+        assert!(diagnostic.contains("matching_releases=0"));
+        assert!(diagnostic
+            .contains("MusicBrainz add missing release group refetch attempt=2: album_id=6"));
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 8);
+        assert!(requests[2].starts_with("GET /api/v1/search?"));
+        let add_album: Value = serde_json::from_str(request_body(&requests[3])).unwrap();
+        assert_eq!(add_album["artistId"], 1);
+        assert_eq!(add_album["artist"]["id"], 1);
+        assert_eq!(add_album["artist"]["artistName"], "Artist");
+        assert_eq!(add_album["artist"]["foreignArtistId"], "artist-mbid");
+        assert_eq!(add_album["artist"]["qualityProfileId"], 7);
+        assert_eq!(add_album["artist"]["metadataProfileId"], 3);
+        assert_eq!(add_album["artist"]["rootFolderPath"], "/music");
+        assert_eq!(add_album["monitored"], false);
+        assert_eq!(add_album["addOptions"]["searchForNewAlbum"], false);
+        assert!(add_album.get("releases").is_none());
+        assert!(requests[6].contains("albumId=6"));
+        let command: Value = serde_json::from_str(request_body(&requests[7])).unwrap();
+        assert_eq!(command["files"][0]["albumId"], 6);
+        assert_eq!(command["files"][0]["albumReleaseId"], 7);
+        assert_eq!(command["files"][2]["trackIds"], serde_json::json!([13]));
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_add_missing_musicbrainz_release_group_does_not_retry_after_add()
+    {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 03 - Three.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let initial_albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"artist":{"id":1,"artistName":"Artist","foreignArtistId":"artist-mbid","qualityProfileId":7,"metadataProfileId":3,"rootFolderPath":"/music"},"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":true,"format":"7\" Vinyl"},
+                {"id":4,"albumId":2,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Album","trackCount":2,"monitored":false,"format":"12\" Vinyl"}
+            ]}
+        ]"#;
+        let search = r#"[
+            {"album":{"id":0,"title":"Album: 3 Happy Songs","foreignAlbumId":"11111111-1111-1111-1111-111111111111","releases":[
+                {"id":99,"albumId":0,"foreignReleaseId":"cccccccc-cccc-cccc-cccc-cccccccccccc","title":"Album: 3 Happy Songs","trackCount":3,"monitored":false,"format":"CD","media":[{"mediumNumber":1}]}
+            ]}}
+        ]"#;
+        let added_album = r#"{"id":6,"title":"Album: 3 Happy Songs","foreignAlbumId":"11111111-1111-1111-1111-111111111111"}"#;
+        let refetched_albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":true,"format":"7\" Vinyl"}
+            ]},
+            {"id":6,"title":"Album: 3 Happy Songs","artistId":1,"foreignAlbumId":"11111111-1111-1111-1111-111111111111","releaseDate":"1984-01-01","releases":[
+                {"id":7,"albumId":6,"foreignReleaseId":"cccccccc-cccc-cccc-cccc-cccccccccccc","title":"Album: 3 Happy Songs","trackCount":2,"monitored":false,"format":"CD"}
+            ]}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", initial_albums),
+            ("200 OK", search),
+            ("201 Created", added_album),
+            ("200 OK", refetched_albums),
+        ])
+        .await;
+        let client = lidarr_client(url, true)
+            .with_musicbrainz_add_missing_release_group(true)
+            .with_musicbrainz_add_album_refetch(1, Duration::ZERO)
+            .with_musicbrainz_disc_release_lookup(Arc::new(FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![musicbrainz_release_with_title(
+                        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                        "Album: 3 Happy Songs",
+                        3,
+                    )],
+                    diagnostic: "MusicBrainz lookup: found 1 release(s)\n".into(),
+                },
+            }))
+            .with_disc_release_lookup(Arc::new(FakeDiscLookup {
+                result: DiscReleaseLookupResult::NotFound {
+                    diagnostic: "GnuDB lookup: no search candidates\n".into(),
+                },
+            }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![
+                    ("/downloads/album/Artist - Album - 01 - One.flac", "One"),
+                    ("/downloads/album/Artist - Album - 02 - Two.flac", "Two"),
+                    ("/downloads/album/Artist - Album - 03 - Three.flac", "Three"),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Skipped { diagnostic, .. } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(diagnostic.contains(
+            "MusicBrainz add missing release group decision: added album has no compatible release"
+        ));
+        assert!(diagnostic.contains("Fallback GnuDB release lookup: evaluating"));
+        let requests = requests.lock().unwrap();
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.starts_with("POST /api/v1/album "))
+                .count(),
+            1
+        );
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.starts_with("GET /api/v1/search?"))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_add_missing_musicbrainz_release_group_skips_ambiguous_groups() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![("200 OK", candidates), ("200 OK", "[]")]).await;
+        let mut first = musicbrainz_release("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 1);
+        first.release_group_id = Some("11111111-1111-1111-1111-111111111111".into());
+        let mut second = musicbrainz_release("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", 1);
+        second.release_group_id = Some("22222222-2222-2222-2222-222222222222".into());
+        let client = lidarr_client(url, true)
+            .with_musicbrainz_add_missing_release_group(true)
+            .with_musicbrainz_disc_release_lookup(Arc::new(FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![first, second],
+                    diagnostic: "MusicBrainz lookup: found 2 release(s)\n".into(),
+                },
+            }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![("/downloads/album/Artist - Album - 01 - One.flac", "One")],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Skipped { diagnostic, .. } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(diagnostic.contains("Fallback MusicBrainz add missing release group: true"));
+        assert!(diagnostic.contains("expected one distinct release-group ID, got 2"));
+        assert_eq!(requests.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_trusted_musicbrainz_disabled_preserves_ambiguous_album_skip() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Kalimba De Luna - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Kalimba De Luna - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Kalimba De Luna - 03 - Three.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Kalimba de luna","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Kalimba de luna","trackCount":2,"monitored":true,"format":"7\" Vinyl"}
+            ]},
+            {"id":4,"title":"Kalimba de Luna: 3 Happy Songs","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":5,"albumId":4,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Kalimba de Luna: 3 Happy Songs","trackCount":3,"monitored":true,"format":"CD"}
+            ]}
+        ]"#;
+        let (url, requests) =
+            serve_sequence(vec![("200 OK", candidates), ("200 OK", albums)]).await;
+        let client = lidarr_client(url, true).with_musicbrainz_disc_release_lookup(Arc::new(
+            FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![musicbrainz_release_with_title(
+                        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                        "Kalimba de Luna: 3 Happy Songs",
+                        3,
+                    )],
+                    diagnostic: "MusicBrainz lookup should not run\n".into(),
+                },
+            },
+        ));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Kalimba De Luna",
+                "/downloads/album",
+                "Kalimba De Luna",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![
+                    (
+                        "/downloads/album/Artist - Kalimba De Luna - 01 - One.flac",
+                        "One",
+                    ),
+                    (
+                        "/downloads/album/Artist - Kalimba De Luna - 02 - Two.flac",
+                        "Two",
+                    ),
+                    (
+                        "/downloads/album/Artist - Kalimba De Luna - 03 - Three.flac",
+                        "Three",
+                    ),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Skipped { reason, diagnostic } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(reason.contains("multiple Lidarr albums matched fallback hints"));
+        assert!(!diagnostic.contains("MusicBrainz lookup should not run"));
+        assert_eq!(requests.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_trusted_musicbrainz_widens_to_matching_album_title() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Kalimba De Luna - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Kalimba De Luna - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Kalimba De Luna - 03 - Three.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Kalimba de luna","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Kalimba de luna","trackCount":2,"monitored":true,"format":"7\" Vinyl"}
+            ]},
+            {"id":4,"title":"Kalimba de Luna: 3 Happy Songs","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":5,"albumId":4,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Kalimba de Luna: 3 Happy Songs","trackCount":3,"monitored":true,"format":"CD"}
+            ]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":4,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"},
+            {"id":12,"albumId":4,"absoluteTrackNumber":2,"trackNumber":"2","title":"Two"},
+            {"id":13,"albumId":4,"absoluteTrackNumber":3,"trackNumber":"3","title":"Three"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true)
+            .with_musicbrainz_trust_disc_lookup(true)
+            .with_musicbrainz_disc_release_lookup(Arc::new(FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![
+                        musicbrainz_release_with_title(
+                            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                            "Kalimba de Luna: 3 Happy Songs",
+                            3,
+                        ),
+                        {
+                            let mut release = musicbrainz_release_with_title(
+                                "dddddddd-dddd-dddd-dddd-dddddddddddd",
+                                "Kalimba de Luna: 3 Happy Songs",
+                                3,
+                            );
+                            release.barcode = None;
+                            release
+                        },
+                    ],
+                    diagnostic: "MusicBrainz lookup: found 2 release(s)\n".into(),
+                },
+            }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Kalimba De Luna",
+                "/downloads/album",
+                "Kalimba De Luna",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![
+                    (
+                        "/downloads/album/Artist - Kalimba De Luna - 01 - One.flac",
+                        "One",
+                    ),
+                    (
+                        "/downloads/album/Artist - Kalimba De Luna - 02 - Two.flac",
+                        "Two",
+                    ),
+                    (
+                        "/downloads/album/Artist - Kalimba De Luna - 03 - Three.flac",
+                        "Three",
+                    ),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started { diagnostic, .. } = result else {
+            panic!("expected manual import to start");
+        };
+        assert!(diagnostic.contains("Fallback album match was ambiguous"));
+        assert!(diagnostic.contains("MusicBrainz trusted titles: [kalimba de luna 3 happy songs]"));
+        assert!(diagnostic.contains("MusicBrainz trusted decision: widened album/release selected"));
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 4);
+        assert!(requests[2].contains("albumId=4"));
+        let command: Value = serde_json::from_str(request_body(&requests[3])).unwrap();
+        assert_eq!(command["files"][0]["albumId"], 4);
+        assert_eq!(command["files"][0]["albumReleaseId"], 5);
+        assert_eq!(command["files"][0]["trackIds"], serde_json::json!([11]));
+        assert_eq!(command["files"][2]["trackIds"], serde_json::json!([13]));
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_ambiguous_musicbrainz_releases_fall_through_to_gnudb() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/Artist - Album - 02 - Two.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2,"monitored":false},
+                {"id":4,"albumId":2,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Album","trackCount":2,"monitored":false}
+            ]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":2,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"},
+            {"id":12,"albumId":2,"absoluteTrackNumber":2,"trackNumber":"2","title":"Two"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true)
+            .with_musicbrainz_disc_release_lookup(Arc::new(FakeMusicBrainzLookup {
+                result: MusicBrainzDiscLookupResult::Found {
+                    releases: vec![
+                        MusicBrainzDiscRelease {
+                            id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".into(),
+                            title: Some("Album".into()),
+                            media_count: 1,
+                            media_track_counts: vec![2],
+                            ..MusicBrainzDiscRelease::default()
+                        },
+                        MusicBrainzDiscRelease {
+                            id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb".into(),
+                            title: Some("Album".into()),
+                            media_count: 1,
+                            media_track_counts: vec![2],
+                            ..MusicBrainzDiscRelease::default()
+                        },
+                    ],
+                    diagnostic: "MusicBrainz lookup: found 2 release(s)\n".into(),
+                },
+            }))
+            .with_disc_release_lookup(Arc::new(FakeDiscLookup {
+                result: DiscReleaseLookupResult::Found {
+                    candidates: vec![DiscReleaseCandidate {
+                        category: "rock".into(),
+                        entry_id: "c60c9d10".into(),
+                        disc_id: "C60C9D10".into(),
+                        artist: Some("Artist".into()),
+                        title: Some("Album".into()),
+                        year: Some(1984),
+                        track_titles: vec!["One".into(), "Two".into()],
+                        art_ids: vec!["bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb".into()],
+                    }],
+                    diagnostic: "GnuDB accepted candidates: 1\n".into(),
+                },
+            }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![
+                    ("/downloads/album/Artist - Album - 01 - One.flac", "One"),
+                    ("/downloads/album/Artist - Album - 02 - Two.flac", "Two"),
+                ],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started { diagnostic, .. } = result else {
+            panic!("expected manual import to start");
+        };
+        assert!(diagnostic.contains("MusicBrainz exact intersection count: 2"));
+        assert!(diagnostic.contains("MusicBrainz decision: ranked candidates tied"));
+        assert!(diagnostic
+            .contains("GnuDB selected foreign_release_id=bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
+        assert_eq!(requests.lock().unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_skips_when_gnudb_artids_do_not_match_lidarr_releases() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":1},
+                {"id":4,"albumId":2,"foreignReleaseId":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb","title":"Album","trackCount":1}
+            ]}
+        ]"#;
+        let (url, requests) =
+            serve_sequence(vec![("200 OK", candidates), ("200 OK", albums)]).await;
+        let client = lidarr_client(url, true).with_disc_release_lookup(Arc::new(FakeDiscLookup {
+            result: DiscReleaseLookupResult::Found {
+                candidates: vec![DiscReleaseCandidate {
+                    category: "rock".into(),
+                    entry_id: "c60c9d10".into(),
+                    disc_id: "C60C9D10".into(),
+                    artist: Some("Artist".into()),
+                    title: Some("Album".into()),
+                    year: Some(1984),
+                    track_titles: vec!["One".into()],
+                    art_ids: vec!["cccccccc-cccc-cccc-cccc-cccccccccccc".into()],
+                }],
+                diagnostic: "GnuDB accepted candidates: 1\n".into(),
+            },
+        }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![("/downloads/album/Artist - Album - 01 - One.flac", "One")],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Skipped { reason, diagnostic } = result else {
+            panic!("expected manual import to skip");
+        };
+        assert!(reason.contains("multiple Lidarr album releases"));
+        assert!(diagnostic.contains("matches=0"));
+        assert_eq!(requests.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn manual_import_fallback_uses_gnudb_when_release_track_count_does_not_match() {
+        let candidates = r#"[
+            {"path":"/downloads/album/Artist - Album - 01 - One.flac","artist":{"id":1,"artistName":"Artist"},"quality":{"quality":{"id":6}}}
+        ]"#;
+        let albums = r#"[
+            {"id":2,"title":"Album","artistId":1,"releaseDate":"1984-01-01","releases":[
+                {"id":3,"albumId":2,"foreignReleaseId":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","trackCount":2}
+            ]}
+        ]"#;
+        let tracks = r#"[
+            {"id":11,"albumId":2,"absoluteTrackNumber":1,"trackNumber":"1","title":"One"}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![
+            ("200 OK", candidates),
+            ("200 OK", albums),
+            ("200 OK", tracks),
+            ("201 Created", r#"{"id":7}"#),
+        ])
+        .await;
+        let client = lidarr_client(url, true).with_disc_release_lookup(Arc::new(FakeDiscLookup {
+            result: DiscReleaseLookupResult::Found {
+                candidates: vec![DiscReleaseCandidate {
+                    category: "rock".into(),
+                    entry_id: "c60c9d10".into(),
+                    disc_id: "C60C9D10".into(),
+                    artist: Some("Artist".into()),
+                    title: Some("Album".into()),
+                    year: Some(1984),
+                    track_titles: vec!["One".into()],
+                    art_ids: vec!["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".into()],
+                }],
+                diagnostic: "GnuDB accepted candidates: 1\n".into(),
+            },
+        }));
+
+        let result = client
+            .trigger_manual_import(manual_import_request_with_metadata_and_disc_id(
+                "Artist - Album",
+                "/downloads/album",
+                "Album",
+                "Artist",
+                "1984",
+                Some("C60C9D10"),
+                vec![("/downloads/album/Artist - Album - 01 - One.flac", "One")],
+            ))
+            .await
+            .unwrap();
+
+        let ManualImportResult::Started { diagnostic, .. } = result else {
+            panic!("expected manual import to start");
+        };
+        assert!(diagnostic.contains("matching_releases=0"));
+        assert!(diagnostic
+            .contains("GnuDB selected foreign_release_id=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+        assert_eq!(requests.lock().unwrap().len(), 4);
     }
 
     fn lidarr_client(url: String, manual_import_enabled: bool) -> LidarrQueueSource {
@@ -760,9 +4686,130 @@ mod tests {
                 album_title: Some("Album".into()),
                 performer: Some("Artist".into()),
                 catalog: None,
+                disc_id: None,
                 comments: Vec::new(),
                 track_count,
+                tracks: (1..=track_count)
+                    .map(|number| CueTrackHint {
+                        number: number.to_string(),
+                        title: None,
+                        performer: Some("Artist".into()),
+                    })
+                    .collect(),
             }],
+        }
+    }
+
+    fn manual_import_request_with_metadata(
+        title: &str,
+        output_path: &str,
+        album_title: &str,
+        performer: &str,
+        year: &str,
+        tracks: Vec<(&str, &str)>,
+    ) -> ManualImportRequest {
+        manual_import_request_with_metadata_and_disc_id(
+            title,
+            output_path,
+            album_title,
+            performer,
+            year,
+            None,
+            tracks,
+        )
+    }
+
+    fn manual_import_request_with_metadata_and_disc_id(
+        title: &str,
+        output_path: &str,
+        album_title: &str,
+        performer: &str,
+        year: &str,
+        disc_id: Option<&str>,
+        tracks: Vec<(&str, &str)>,
+    ) -> ManualImportRequest {
+        ManualImportRequest {
+            download: TrackedDownload::pending(
+                "download-1".into(),
+                title.into(),
+                "completed".into(),
+                output_path.into(),
+                "importFailed".into(),
+            ),
+            generated_tracks: tracks.iter().map(|(path, _)| PathBuf::from(path)).collect(),
+            cue_hints: vec![CueMetadataHint {
+                path: PathBuf::from(format!("{output_path}/album.cue")),
+                album_title: Some(album_title.into()),
+                performer: Some(performer.into()),
+                catalog: None,
+                disc_id: disc_id.map(str::to_owned),
+                comments: vec![("DATE".into(), year.into())],
+                track_count: tracks.len(),
+                tracks: tracks
+                    .iter()
+                    .enumerate()
+                    .map(|(index, (_, title))| CueTrackHint {
+                        number: (index + 1).to_string(),
+                        title: Some((*title).into()),
+                        performer: Some(performer.into()),
+                    })
+                    .collect(),
+            }],
+        }
+    }
+
+    struct FakeDiscLookup {
+        result: DiscReleaseLookupResult,
+    }
+
+    #[async_trait::async_trait]
+    impl DiscReleaseLookup for FakeDiscLookup {
+        async fn lookup_disc_release(
+            &self,
+            _request: DiscReleaseLookupRequest,
+        ) -> anyhow::Result<DiscReleaseLookupResult> {
+            Ok(self.result.clone())
+        }
+    }
+
+    struct FakeMusicBrainzLookup {
+        result: MusicBrainzDiscLookupResult,
+    }
+
+    #[async_trait::async_trait]
+    impl MusicBrainzDiscReleaseLookup for FakeMusicBrainzLookup {
+        async fn lookup_musicbrainz_disc_releases(
+            &self,
+            _request: MusicBrainzDiscLookupRequest,
+        ) -> anyhow::Result<MusicBrainzDiscLookupResult> {
+            Ok(self.result.clone())
+        }
+    }
+
+    fn musicbrainz_release(id: &str, track_count: usize) -> MusicBrainzDiscRelease {
+        musicbrainz_release_with_title(id, "Album", track_count)
+    }
+
+    fn musicbrainz_release_with_title(
+        id: &str,
+        title: &str,
+        track_count: usize,
+    ) -> MusicBrainzDiscRelease {
+        MusicBrainzDiscRelease {
+            id: id.into(),
+            title: Some(title.into()),
+            date: Some("1984-01-01".into()),
+            country: Some("DE".into()),
+            status: Some("Official".into()),
+            barcode: Some("1234567890123".into()),
+            quality: Some("normal".into()),
+            media_count: 1,
+            media_formats: vec!["CD".into()],
+            media_track_counts: vec![track_count],
+            label_count: 1,
+            release_group_id: Some("11111111-1111-1111-1111-111111111111".into()),
+            release_group_title: Some(title.into()),
+            release_group_first_release_date: Some("1984".into()),
         }
     }
 

--- a/src/adapters/lidarr_api.rs
+++ b/src/adapters/lidarr_api.rs
@@ -1,9 +1,13 @@
 use std::collections::HashSet;
+use std::path::Path;
 
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
-use crate::application::ports::QueueSource;
+use crate::application::ports::{
+    ManualImportRequest, ManualImportResult, ManualImportTrigger, QueueSource,
+};
 use crate::bootstrap::settings::LidarrSettings;
 use crate::domain::{FailedImportCandidate, QueueSnapshot};
 
@@ -13,6 +17,7 @@ pub struct LidarrQueueSource {
     api_key: String,
     page_size: usize,
     max_pages: usize,
+    manual_import_enabled: bool,
     client: reqwest::Client,
 }
 
@@ -47,6 +52,7 @@ impl LidarrQueueSource {
             api_key: settings.api_key.clone(),
             page_size: settings.queue_page_size.max(1),
             max_pages: settings.queue_max_pages.max(1),
+            manual_import_enabled: settings.manual_import_enabled,
             client: reqwest::Client::new(),
         }
     }
@@ -131,6 +137,86 @@ impl QueueSource for LidarrQueueSource {
     }
 }
 
+impl ManualImportTrigger for LidarrQueueSource {
+    async fn trigger_manual_import(
+        &self,
+        request: ManualImportRequest,
+    ) -> Result<ManualImportResult> {
+        if !self.manual_import_enabled {
+            return Ok(ManualImportResult::Disabled);
+        }
+
+        let response = self
+            .client
+            .get(format!("{}/api/v1/manualimport", self.base_url))
+            .query(&[
+                ("folder", request.download.output_path.as_str()),
+                ("downloadId", request.download.download_id.as_str()),
+                ("filterExistingFiles", "true"),
+                ("replaceExistingFiles", "true"),
+            ])
+            .header("x-api-key", &self.api_key)
+            .send()
+            .await
+            .map_err(|err| anyhow!("failed requesting lidarr manual import candidates: {err}"))?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|err| anyhow!("failed reading lidarr manual import candidates: {err}"))?;
+
+        if !status.is_success() {
+            return Err(anyhow!(
+                "lidarr returned HTTP {status} for manual import candidates: {body}"
+            ));
+        }
+
+        let candidates: Vec<ManualImportResource> = serde_json::from_str(&body).map_err(|err| {
+            anyhow!("lidarr returned invalid manual import JSON: {err}; body: {body}")
+        })?;
+        let files = match select_manual_import_files(&request, candidates)? {
+            Some(files) => files,
+            None => {
+                return Ok(ManualImportResult::Skipped {
+                    reason: "lidarr did not return one complete album release match".into(),
+                });
+            }
+        };
+        let imported_track_count = files.len();
+        let command = ManualImportCommand {
+            name: "ManualImport",
+            import_mode: "Move",
+            replace_existing_files: true,
+            files,
+        };
+        let command_body = serde_json::to_string(&command)
+            .map_err(|err| anyhow!("failed serializing lidarr manual import command: {err}"))?;
+        let response = self
+            .client
+            .post(format!("{}/api/v1/command", self.base_url))
+            .header("x-api-key", &self.api_key)
+            .header("content-type", "application/json")
+            .body(command_body)
+            .send()
+            .await
+            .map_err(|err| anyhow!("failed starting lidarr manual import command: {err}"))?;
+        let status = response.status();
+        let body = response.text().await.map_err(|err| {
+            anyhow!("failed reading lidarr manual import command response: {err}")
+        })?;
+
+        if !status.is_success() {
+            return Err(anyhow!(
+                "lidarr returned HTTP {status} for manual import command: {body}"
+            ));
+        }
+
+        Ok(ManualImportResult::Started {
+            imported_track_count,
+        })
+    }
+}
+
 impl QueueRecord {
     fn download_id(&self) -> Option<&str> {
         self.download_id
@@ -165,18 +251,201 @@ impl QueueRecord {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ManualImportResource {
+    path: String,
+    #[serde(default)]
+    artist: Option<ManualImportArtist>,
+    #[serde(default)]
+    album: Option<ManualImportAlbum>,
+    #[serde(default)]
+    album_release_id: i64,
+    #[serde(default)]
+    tracks: Vec<ManualImportTrack>,
+    #[serde(default)]
+    quality: Option<Value>,
+    #[serde(default)]
+    indexer_flags: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ManualImportArtist {
+    id: i64,
+    #[serde(default)]
+    artist_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ManualImportAlbum {
+    id: i64,
+    #[serde(default)]
+    title: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ManualImportTrack {
+    id: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ManualImportCommand {
+    name: &'static str,
+    import_mode: &'static str,
+    replace_existing_files: bool,
+    files: Vec<ManualImportFile>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ManualImportFile {
+    path: String,
+    artist_id: i64,
+    album_id: i64,
+    album_release_id: i64,
+    track_ids: Vec<i64>,
+    quality: Value,
+    indexer_flags: i64,
+    download_id: String,
+    disable_release_switching: bool,
+}
+
+fn select_manual_import_files(
+    request: &ManualImportRequest,
+    candidates: Vec<ManualImportResource>,
+) -> Result<Option<Vec<ManualImportFile>>> {
+    let mut selected = Vec::with_capacity(request.generated_tracks.len());
+
+    for generated_track in &request.generated_tracks {
+        let matches = candidates
+            .iter()
+            .filter(|candidate| paths_match(&candidate.path, generated_track))
+            .collect::<Vec<_>>();
+        if matches.len() != 1 {
+            return Ok(None);
+        }
+
+        let Some(file) = manual_import_file(&request.download.download_id, matches[0]) else {
+            return Ok(None);
+        };
+        selected.push(file);
+    }
+
+    if selected.is_empty() || !one_album_release(&selected) {
+        return Ok(None);
+    }
+    if !cue_hints_match(request, &candidates, &selected) {
+        return Ok(None);
+    }
+
+    Ok(Some(selected))
+}
+
+fn paths_match(candidate_path: &str, generated_track: &Path) -> bool {
+    Path::new(candidate_path) == generated_track
+}
+
+fn manual_import_file(download_id: &str, item: &ManualImportResource) -> Option<ManualImportFile> {
+    let artist_id = item.artist.as_ref()?.id;
+    let album_id = item.album.as_ref()?.id;
+    if item.album_release_id <= 0 {
+        return None;
+    }
+    let quality = item.quality.clone()?;
+    let track_ids = item.tracks.iter().map(|track| track.id).collect::<Vec<_>>();
+    if track_ids.is_empty() {
+        return None;
+    }
+
+    Some(ManualImportFile {
+        path: item.path.clone(),
+        artist_id,
+        album_id,
+        album_release_id: item.album_release_id,
+        track_ids,
+        quality,
+        indexer_flags: item.indexer_flags,
+        download_id: download_id.to_owned(),
+        disable_release_switching: false,
+    })
+}
+
+fn one_album_release(files: &[ManualImportFile]) -> bool {
+    let first = &files[0];
+    files.iter().all(|file| {
+        file.artist_id == first.artist_id
+            && file.album_id == first.album_id
+            && file.album_release_id == first.album_release_id
+    })
+}
+
+fn cue_hints_match(
+    request: &ManualImportRequest,
+    candidates: &[ManualImportResource],
+    selected: &[ManualImportFile],
+) -> bool {
+    let expected_track_count = request
+        .cue_hints
+        .iter()
+        .map(|hint| hint.track_count)
+        .sum::<usize>();
+    if expected_track_count > 0 && expected_track_count != selected.len() {
+        return false;
+    }
+
+    let album_titles = request
+        .cue_hints
+        .iter()
+        .filter_map(|hint| hint.album_title.as_deref())
+        .map(normalize_hint)
+        .collect::<HashSet<_>>();
+    if album_titles.len() == 1 {
+        let selected_album_titles = candidates
+            .iter()
+            .filter(|candidate| {
+                selected
+                    .iter()
+                    .any(|file| paths_match(&candidate.path, Path::new(&file.path)))
+            })
+            .filter_map(|candidate| candidate.album.as_ref()?.title.as_deref())
+            .map(normalize_hint)
+            .collect::<HashSet<_>>();
+        if !selected_album_titles.is_empty()
+            && selected_album_titles
+                .iter()
+                .all(|title| !album_titles.contains(title))
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn normalize_hint(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
 
+    use serde_json::Value;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
     use super::LidarrQueueSource;
-    use crate::application::ports::QueueSource;
+    use crate::application::ports::{
+        CueMetadataHint, ManualImportRequest, ManualImportResult, ManualImportTrigger, QueueSource,
+    };
     use crate::bootstrap::settings::LidarrSettings;
-    use crate::domain::FailedImportCandidate;
+    use crate::domain::{FailedImportCandidate, TrackedDownload};
 
     #[test]
     fn queue_record_candidate_requires_import_failed_completed_with_path() {
@@ -213,6 +482,7 @@ mod tests {
             api_key: "secret".to_owned(),
             queue_page_size: 100,
             queue_max_pages: 100,
+            manual_import_enabled: false,
         });
 
         let queue = client.queue_snapshot().await.unwrap();
@@ -240,6 +510,7 @@ mod tests {
             api_key: "secret".to_owned(),
             queue_page_size: 1,
             queue_max_pages: 100,
+            manual_import_enabled: false,
         });
 
         let queue = client.queue_snapshot().await.unwrap();
@@ -263,6 +534,7 @@ mod tests {
             api_key: "secret".to_owned(),
             queue_page_size: 100,
             queue_max_pages: 100,
+            manual_import_enabled: false,
         });
 
         let queue = client.queue_snapshot().await.unwrap();
@@ -285,6 +557,7 @@ mod tests {
             api_key: "secret".to_owned(),
             queue_page_size: 1,
             queue_max_pages: 100,
+            manual_import_enabled: false,
         });
 
         let queue = client.queue_snapshot().await.unwrap();
@@ -300,6 +573,7 @@ mod tests {
             api_key: "secret".to_owned(),
             queue_page_size: 100,
             queue_max_pages: 100,
+            manual_import_enabled: false,
         });
 
         let err = client.queue_snapshot().await.unwrap_err();
@@ -316,6 +590,7 @@ mod tests {
             api_key: "secret".to_owned(),
             queue_page_size: 100,
             queue_max_pages: 100,
+            manual_import_enabled: false,
         });
 
         let err = client.queue_snapshot().await.unwrap_err();
@@ -346,10 +621,153 @@ mod tests {
             api_key: "secret".to_owned(),
             queue_page_size: 1,
             queue_max_pages: 2,
+            manual_import_enabled: false,
         });
 
         let err = client.queue_snapshot().await.unwrap_err();
         assert!(err.to_string().contains("exceeded max pages"));
+    }
+
+    #[tokio::test]
+    async fn manual_import_disabled_makes_no_request() {
+        let (url, requests) = serve_sequence(Vec::new()).await;
+        let client = lidarr_client(url, false);
+
+        let result = client
+            .trigger_manual_import(manual_import_request(vec!["/downloads/album/01.flac"], 1))
+            .await
+            .unwrap();
+
+        assert_eq!(result, ManualImportResult::Disabled);
+        assert!(requests.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn manual_import_starts_command_for_one_album_release() {
+        let candidates = r#"[
+            {"path":"/downloads/album/01.flac","artist":{"id":1,"artistName":"Artist"},"album":{"id":2,"title":"Album"},"albumReleaseId":3,"tracks":[{"id":11}],"quality":{"quality":{"id":6,"name":"FLAC"},"revision":{"version":1,"real":0}},"indexerFlags":0},
+            {"path":"/downloads/album/02.flac","artist":{"id":1,"artistName":"Artist"},"album":{"id":2,"title":"Album"},"albumReleaseId":3,"tracks":[{"id":12}],"quality":{"quality":{"id":6,"name":"FLAC"},"revision":{"version":1,"real":0}},"indexerFlags":0}
+        ]"#;
+        let (url, requests) =
+            serve_sequence(vec![("200 OK", candidates), ("201 Created", r#"{"id":7}"#)]).await;
+        let client = lidarr_client(url, true);
+
+        let result = client
+            .trigger_manual_import(manual_import_request(
+                vec!["/downloads/album/01.flac", "/downloads/album/02.flac"],
+                2,
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            ManualImportResult::Started {
+                imported_track_count: 2
+            }
+        );
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].starts_with("GET /api/v1/manualimport?"));
+        assert!(requests[0].contains("downloadId=download-1"));
+        assert!(requests[1].starts_with("POST /api/v1/command "));
+
+        let body = request_body(&requests[1]);
+        let command: Value = serde_json::from_str(body).unwrap();
+        assert_eq!(command["name"], "ManualImport");
+        assert_eq!(command["importMode"], "Move");
+        assert_eq!(command["replaceExistingFiles"], true);
+        assert_eq!(command["files"].as_array().unwrap().len(), 2);
+        assert_eq!(command["files"][0]["albumReleaseId"], 3);
+        assert_eq!(command["files"][0]["trackIds"], serde_json::json!([11]));
+        assert_eq!(command["files"][0]["downloadId"], "download-1");
+    }
+
+    #[tokio::test]
+    async fn manual_import_skips_multiple_album_releases() {
+        let candidates = r#"[
+            {"path":"/downloads/album/01.flac","artist":{"id":1},"album":{"id":2,"title":"Album"},"albumReleaseId":3,"tracks":[{"id":11}],"quality":{"quality":{"id":6}}},
+            {"path":"/downloads/album/02.flac","artist":{"id":1},"album":{"id":2,"title":"Album"},"albumReleaseId":4,"tracks":[{"id":12}],"quality":{"quality":{"id":6}}}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![("200 OK", candidates)]).await;
+        let client = lidarr_client(url, true);
+
+        let result = client
+            .trigger_manual_import(manual_import_request(
+                vec!["/downloads/album/01.flac", "/downloads/album/02.flac"],
+                2,
+            ))
+            .await
+            .unwrap();
+
+        assert!(matches!(result, ManualImportResult::Skipped { .. }));
+        assert_eq!(requests.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn manual_import_skips_incomplete_candidates() {
+        let candidates = r#"[
+            {"path":"/downloads/album/01.flac","artist":{"id":1},"album":{"id":2,"title":"Album"},"albumReleaseId":3,"tracks":[{"id":11}]}
+        ]"#;
+        let (url, requests) = serve_sequence(vec![("200 OK", candidates)]).await;
+        let client = lidarr_client(url, true);
+
+        let result = client
+            .trigger_manual_import(manual_import_request(vec!["/downloads/album/01.flac"], 1))
+            .await
+            .unwrap();
+
+        assert!(matches!(result, ManualImportResult::Skipped { .. }));
+        assert_eq!(requests.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn manual_import_reports_api_errors() {
+        let url = serve_once("500 Internal Server Error", "boom").await;
+        let client = lidarr_client(url, true);
+
+        let err = client
+            .trigger_manual_import(manual_import_request(vec!["/downloads/album/01.flac"], 1))
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("HTTP 500"));
+        assert!(err.to_string().contains("manual import candidates"));
+    }
+
+    fn lidarr_client(url: String, manual_import_enabled: bool) -> LidarrQueueSource {
+        LidarrQueueSource::new(&LidarrSettings {
+            url,
+            api_key: "secret".to_owned(),
+            queue_page_size: 100,
+            queue_max_pages: 100,
+            manual_import_enabled,
+        })
+    }
+
+    fn manual_import_request(paths: Vec<&str>, track_count: usize) -> ManualImportRequest {
+        ManualImportRequest {
+            download: TrackedDownload::pending(
+                "download-1".into(),
+                "Artist - Album".into(),
+                "completed".into(),
+                "/downloads/album".into(),
+                "importFailed".into(),
+            ),
+            generated_tracks: paths.into_iter().map(PathBuf::from).collect(),
+            cue_hints: vec![CueMetadataHint {
+                path: PathBuf::from("/downloads/album/album.cue"),
+                album_title: Some("Album".into()),
+                performer: Some("Artist".into()),
+                catalog: None,
+                comments: Vec::new(),
+                track_count,
+            }],
+        }
+    }
+
+    fn request_body(request: &str) -> &str {
+        request.split("\r\n\r\n").nth(1).unwrap_or_default()
     }
 
     async fn serve_once(status: &'static str, body: &'static str) -> String {
@@ -362,8 +780,8 @@ mod tests {
     ) -> (String, Arc<Mutex<Vec<String>>>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let request_lines = Arc::new(Mutex::new(Vec::new()));
-        let shared_lines = Arc::clone(&request_lines);
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let shared_requests = Arc::clone(&requests);
         let shared_responses = Arc::new(Mutex::new(
             responses
                 .into_iter()
@@ -382,9 +800,10 @@ mod tests {
                 let mut request = [0_u8; 4096];
                 let bytes_read = socket.read(&mut request).await.unwrap();
                 let request_text = String::from_utf8_lossy(&request[..bytes_read]);
-                if let Some(line) = request_text.lines().next() {
-                    shared_lines.lock().unwrap().push(line.to_owned());
-                }
+                shared_requests
+                    .lock()
+                    .unwrap()
+                    .push(request_text.into_owned());
 
                 let response = format!(
                     "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -394,6 +813,6 @@ mod tests {
             }
         });
 
-        (format!("http://{addr}"), request_lines)
+        (format!("http://{addr}"), requests)
     }
 }

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,7 +1,10 @@
 pub mod filesystem_cleanup;
 pub mod filesystem_cue_input_inspector;
 pub mod filesystem_cue_scanner;
+pub mod filesystem_download_log;
+pub mod gnudb_api;
 pub mod lidarr_api;
+pub mod musicbrainz_api;
 pub mod shnsplit_splitter;
 pub mod sqlite_download_store;
 pub mod web;

--- a/src/adapters/musicbrainz_api.rs
+++ b/src/adapters/musicbrainz_api.rs
@@ -1,0 +1,872 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use base64::Engine;
+use rcue::parser::parse_from_file;
+use reqwest::Client;
+use serde::Deserialize;
+use sha1::{Digest, Sha1};
+use tokio::time::sleep;
+
+use crate::application::ports::{
+    MusicBrainzDiscLookupRequest, MusicBrainzDiscLookupResult, MusicBrainzDiscRelease,
+    MusicBrainzDiscReleaseLookup,
+};
+use crate::bootstrap::settings::MusicBrainzSettings;
+
+const CD_FRAMES_PER_SECOND: u64 = 75;
+const CD_LEAD_IN_FRAMES: u64 = 150;
+const CD_SAMPLE_RATE: u64 = 44_100;
+const SPLITTARR_USER_AGENT: &str = concat!("Splittarr/", env!("CARGO_PKG_VERSION"));
+const MUSICBRAINZ_DISC_ID_INC: &str = "artists+recordings+release-groups";
+
+#[derive(Debug, Clone)]
+pub struct FilesystemMusicBrainzDiscReleaseLookup {
+    enabled: bool,
+    base_url: String,
+    client: Client,
+    rate_limiter: Arc<MusicBrainzRateLimiter>,
+}
+
+impl FilesystemMusicBrainzDiscReleaseLookup {
+    pub fn new(settings: &MusicBrainzSettings) -> Self {
+        Self {
+            enabled: settings.disc_lookup_enabled,
+            base_url: settings.base_url.trim_end_matches('/').to_owned(),
+            client: Client::new(),
+            rate_limiter: global_rate_limiter(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_rate_limiter(mut self, rate_limiter: Arc<MusicBrainzRateLimiter>) -> Self {
+        self.rate_limiter = rate_limiter;
+        self
+    }
+
+    async fn lookup_releases(
+        &self,
+        toc: &MusicBrainzToc,
+        diagnostic: &mut String,
+    ) -> Result<Vec<MusicBrainzDiscRelease>> {
+        let path = format!("/ws/2/discid/{}", toc.disc_id);
+        let url = format!("{}{}", self.base_url, path);
+        diagnostic.push_str(&format!(
+            "MusicBrainz request: path={} query=toc={}&inc={}&fmt=json\n",
+            path, toc.toc, MUSICBRAINZ_DISC_ID_INC
+        ));
+
+        self.rate_limiter.until_ready().await;
+        let response = self
+            .client
+            .get(url)
+            .query(&[
+                ("toc", toc.toc.as_str()),
+                ("inc", MUSICBRAINZ_DISC_ID_INC),
+                ("fmt", "json"),
+            ])
+            .header("user-agent", SPLITTARR_USER_AGENT)
+            .send()
+            .await
+            .map_err(|err| anyhow!("failed requesting MusicBrainz: {err}"))?;
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|err| anyhow!("failed reading MusicBrainz response: {err}"))?;
+        if !status.is_success() {
+            return Err(anyhow!("MusicBrainz returned HTTP {status}: {body}"));
+        }
+
+        let response: MusicBrainzDiscIdResponse = serde_json::from_str(&body)
+            .map_err(|err| anyhow!("MusicBrainz returned invalid JSON: {err}; body: {body}"))?;
+        let releases = response
+            .releases
+            .into_iter()
+            .filter(|release| !release.id.trim().is_empty())
+            .map(|release| MusicBrainzDiscRelease {
+                id: release.id,
+                title: release.title,
+                date: release.date,
+                country: release.country,
+                status: release.status,
+                barcode: release.barcode.filter(|barcode| !barcode.trim().is_empty()),
+                quality: release.quality,
+                media_count: release.media.len(),
+                media_formats: release
+                    .media
+                    .iter()
+                    .filter_map(|medium| medium.format.clone())
+                    .collect(),
+                media_track_counts: release
+                    .media
+                    .iter()
+                    .filter_map(|medium| medium.track_count)
+                    .collect(),
+                label_count: release.label_info.len(),
+                release_group_id: release
+                    .release_group
+                    .as_ref()
+                    .and_then(|release_group| release_group.id.clone())
+                    .filter(|id| !id.trim().is_empty()),
+                release_group_title: release
+                    .release_group
+                    .as_ref()
+                    .and_then(|release_group| release_group.title.clone()),
+                release_group_first_release_date: release
+                    .release_group
+                    .as_ref()
+                    .and_then(|release_group| release_group.first_release_date.clone()),
+            })
+            .collect::<Vec<_>>();
+        for release in &releases {
+            diagnostic.push_str(&format!(
+                "MusicBrainz response release: id={} title={} date={} country={} status={} barcode_present={} quality={} media_count={} formats=[{}] track_counts=[{}] labels={} release_group_id={} release_group={} release_group_first_release_date={}\n",
+                release.id,
+                release.title.as_deref().unwrap_or("-"),
+                release.date.as_deref().unwrap_or("-"),
+                release.country.as_deref().unwrap_or("-"),
+                release.status.as_deref().unwrap_or("-"),
+                release.barcode.is_some(),
+                release.quality.as_deref().unwrap_or("-"),
+                release.media_count,
+                release.media_formats.join(", "),
+                release
+                    .media_track_counts
+                    .iter()
+                    .map(usize::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                release.label_count,
+                release.release_group_id.as_deref().unwrap_or("-"),
+                release.release_group_title.as_deref().unwrap_or("-"),
+                release
+                    .release_group_first_release_date
+                    .as_deref()
+                    .unwrap_or("-")
+            ));
+        }
+
+        Ok(releases)
+    }
+}
+
+#[async_trait]
+impl MusicBrainzDiscReleaseLookup for FilesystemMusicBrainzDiscReleaseLookup {
+    async fn lookup_musicbrainz_disc_releases(
+        &self,
+        request: MusicBrainzDiscLookupRequest,
+    ) -> Result<MusicBrainzDiscLookupResult> {
+        if !self.enabled {
+            return Ok(MusicBrainzDiscLookupResult::Disabled {
+                diagnostic: "MusicBrainz lookup: disabled\n".into(),
+            });
+        }
+
+        let mut diagnostic = String::from("MusicBrainz lookup: enabled\n");
+        let toc = match build_musicbrainz_toc(&request.cue_paths) {
+            Ok(toc) => toc,
+            Err(err) => {
+                diagnostic.push_str(&format!("MusicBrainz lookup: skipped: {err}\n"));
+                return Ok(MusicBrainzDiscLookupResult::NotFound { diagnostic });
+            }
+        };
+        diagnostic.push_str(&toc.diagnostic);
+
+        let releases = match self.lookup_releases(&toc, &mut diagnostic).await {
+            Ok(releases) => releases,
+            Err(err) => {
+                diagnostic.push_str(&format!("MusicBrainz lookup failed: {err}\n"));
+                return Ok(MusicBrainzDiscLookupResult::NotFound { diagnostic });
+            }
+        };
+
+        if releases.is_empty() {
+            diagnostic.push_str("MusicBrainz lookup: no releases\n");
+            Ok(MusicBrainzDiscLookupResult::NotFound { diagnostic })
+        } else {
+            diagnostic.push_str(&format!(
+                "MusicBrainz lookup: found {} release(s)\n",
+                releases.len()
+            ));
+            Ok(MusicBrainzDiscLookupResult::Found {
+                releases,
+                diagnostic,
+            })
+        }
+    }
+}
+
+#[derive(Debug)]
+struct MusicBrainzToc {
+    toc: String,
+    disc_id: String,
+    diagnostic: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AudioFileLength {
+    path: PathBuf,
+    samples: u64,
+    sample_rate: u64,
+    cd_frames: u64,
+}
+
+fn build_musicbrainz_toc(cue_paths: &[PathBuf]) -> Result<MusicBrainzToc> {
+    let mut diagnostic = String::new();
+    if cue_paths.is_empty() {
+        return Err(anyhow!("no CUE paths were provided"));
+    }
+
+    let mut track_offsets = Vec::new();
+    let mut current_file_start = 0_u64;
+    let mut audio_lengths = Vec::new();
+    for cue_path in cue_paths {
+        diagnostic.push_str(&format!(
+            "MusicBrainz TOC CUE path: {}\n",
+            cue_path.display()
+        ));
+        let cue = parse_from_file(&cue_path.to_string_lossy(), false)
+            .map_err(|err| anyhow!("failed to parse CUE {}: {err}", cue_path.display()))?;
+        let cue_dir = cue_path.parent().unwrap_or_else(|| Path::new("."));
+
+        for cue_file in cue.files {
+            let audio_path = cue_dir.join(&cue_file.file);
+            let audio = read_audio_file_length(&audio_path)?;
+            diagnostic.push_str(&format!(
+                "MusicBrainz TOC audio: path={} samples={} sample_rate={} cd_frames={}\n",
+                audio.path.display(),
+                audio.samples,
+                audio.sample_rate,
+                audio.cd_frames
+            ));
+
+            for track in cue_file.tracks {
+                if !track.format.eq_ignore_ascii_case("AUDIO") {
+                    diagnostic.push_str(&format!(
+                        "MusicBrainz TOC skipped non-audio track: number={} format={}\n",
+                        track.no, track.format
+                    ));
+                    continue;
+                }
+                let Some(index_offset) = track_index_01_frames(&track) else {
+                    diagnostic.push_str(&format!(
+                        "MusicBrainz TOC skipped track without INDEX 01: number={}\n",
+                        track.no
+                    ));
+                    continue;
+                };
+                track_offsets.push(current_file_start + index_offset + CD_LEAD_IN_FRAMES);
+            }
+
+            current_file_start += audio.cd_frames;
+            audio_lengths.push(audio);
+        }
+    }
+
+    if track_offsets.is_empty() {
+        return Err(anyhow!("no audio tracks with INDEX 01 were found"));
+    }
+    if track_offsets.len() > 99 {
+        return Err(anyhow!(
+            "MusicBrainz TOC has too many tracks: {}",
+            track_offsets.len()
+        ));
+    }
+
+    let first_track = 1_u64;
+    let last_track = track_offsets.len() as u64;
+    let leadout = current_file_start + CD_LEAD_IN_FRAMES;
+    let toc = std::iter::once(first_track.to_string())
+        .chain(std::iter::once(last_track.to_string()))
+        .chain(std::iter::once(leadout.to_string()))
+        .chain(track_offsets.iter().map(u64::to_string))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let disc_id = musicbrainz_disc_id(first_track, last_track, leadout, &track_offsets);
+
+    diagnostic.push_str(&format!(
+        "MusicBrainz TOC track offsets: [{}]\n",
+        track_offsets
+            .iter()
+            .map(u64::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+    diagnostic.push_str(&format!("MusicBrainz TOC leadout: {leadout}\n"));
+    diagnostic.push_str(&format!("MusicBrainz TOC string: {toc}\n"));
+    diagnostic.push_str(&format!("MusicBrainz Disc ID: {disc_id}\n"));
+
+    Ok(MusicBrainzToc {
+        toc,
+        disc_id,
+        diagnostic,
+    })
+}
+
+fn track_index_01_frames(track: &rcue::cue::Track) -> Option<u64> {
+    track
+        .indices
+        .iter()
+        .find(|(index, _)| index == "01")
+        .map(|(_, duration)| duration_to_cd_frames(*duration))
+}
+
+fn duration_to_cd_frames(duration: Duration) -> u64 {
+    duration.as_secs() * CD_FRAMES_PER_SECOND
+        + ((u64::from(duration.subsec_nanos()) * CD_FRAMES_PER_SECOND + 500_000_000)
+            / 1_000_000_000)
+}
+
+fn read_audio_file_length(path: &Path) -> Result<AudioFileLength> {
+    if !path.exists() {
+        return Err(anyhow!(
+            "referenced audio file is missing: {}",
+            path.display()
+        ));
+    }
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("flac") => read_flac_file_length(path),
+        Some("wav") | Some("wave") => read_wav_file_length(path),
+        Some(extension) => Err(anyhow!(
+            "unsupported referenced audio extension .{} for {}",
+            extension,
+            path.display()
+        )),
+        None => Err(anyhow!(
+            "referenced audio file has no extension: {}",
+            path.display()
+        )),
+    }
+}
+
+fn read_flac_file_length(path: &Path) -> Result<AudioFileLength> {
+    let output = Command::new("metaflac")
+        .arg("--show-total-samples")
+        .arg("--show-sample-rate")
+        .arg(path)
+        .output()
+        .map_err(|err| anyhow!("failed to run metaflac for {}: {err}", path.display()))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "metaflac failed for {}: {}",
+            path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    let values = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| line.parse::<u64>())
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|err| {
+            anyhow!(
+                "metaflac output was not numeric for {}: {err}",
+                path.display()
+            )
+        })?;
+    if values.len() != 2 {
+        return Err(anyhow!(
+            "metaflac returned {} value(s) for {}, expected total samples and sample rate",
+            values.len(),
+            path.display()
+        ));
+    }
+    audio_length(path, values[0], values[1])
+}
+
+fn read_wav_file_length(path: &Path) -> Result<AudioFileLength> {
+    let mut file =
+        File::open(path).map_err(|err| anyhow!("failed to open WAV {}: {err}", path.display()))?;
+    let mut riff = [0_u8; 12];
+    file.read_exact(&mut riff)
+        .map_err(|err| anyhow!("failed to read WAV header {}: {err}", path.display()))?;
+    if &riff[0..4] != b"RIFF" || &riff[8..12] != b"WAVE" {
+        return Err(anyhow!("unsupported WAV layout for {}", path.display()));
+    }
+
+    let mut format_tag = None;
+    let mut sample_rate = None;
+    let mut block_align = None;
+    let mut data_size = None;
+
+    loop {
+        let mut header = [0_u8; 8];
+        match file.read_exact(&mut header) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(err) => {
+                return Err(anyhow!(
+                    "failed to read WAV chunk {}: {err}",
+                    path.display()
+                ))
+            }
+        }
+        let chunk_id = &header[0..4];
+        let chunk_size = u32::from_le_bytes(header[4..8].try_into().expect("slice length")) as u64;
+        let chunk_start = file
+            .stream_position()
+            .map_err(|err| anyhow!("failed to inspect WAV {}: {err}", path.display()))?;
+
+        if chunk_id == b"fmt " {
+            let mut fmt = vec![0_u8; chunk_size as usize];
+            file.read_exact(&mut fmt)
+                .map_err(|err| anyhow!("failed to read WAV fmt chunk {}: {err}", path.display()))?;
+            if fmt.len() < 16 {
+                return Err(anyhow!("unsupported WAV fmt chunk for {}", path.display()));
+            }
+            format_tag = Some(u16::from_le_bytes([fmt[0], fmt[1]]));
+            sample_rate = Some(u32::from_le_bytes([fmt[4], fmt[5], fmt[6], fmt[7]]) as u64);
+            block_align = Some(u16::from_le_bytes([fmt[12], fmt[13]]) as u64);
+        } else if chunk_id == b"data" {
+            data_size = Some(chunk_size);
+            file.seek(SeekFrom::Current(chunk_size as i64))
+                .map_err(|err| anyhow!("failed to skip WAV data {}: {err}", path.display()))?;
+        } else {
+            file.seek(SeekFrom::Current(chunk_size as i64))
+                .map_err(|err| anyhow!("failed to skip WAV chunk {}: {err}", path.display()))?;
+        }
+
+        if chunk_size % 2 == 1 {
+            file.seek(SeekFrom::Start(chunk_start + chunk_size + 1))
+                .map_err(|err| anyhow!("failed to skip WAV padding {}: {err}", path.display()))?;
+        }
+    }
+
+    match format_tag {
+        Some(1 | 0xfffe) => {}
+        Some(tag) => {
+            return Err(anyhow!(
+                "unsupported WAV format tag {} for {}",
+                tag,
+                path.display()
+            ));
+        }
+        None => return Err(anyhow!("WAV fmt chunk is missing for {}", path.display())),
+    }
+    let sample_rate =
+        sample_rate.ok_or_else(|| anyhow!("WAV sample rate is missing for {}", path.display()))?;
+    let block_align =
+        block_align.ok_or_else(|| anyhow!("WAV block align is missing for {}", path.display()))?;
+    if block_align == 0 {
+        return Err(anyhow!("WAV block align is zero for {}", path.display()));
+    }
+    let data_size =
+        data_size.ok_or_else(|| anyhow!("WAV data chunk is missing for {}", path.display()))?;
+    audio_length(path, data_size / block_align, sample_rate)
+}
+
+fn audio_length(path: &Path, samples: u64, sample_rate: u64) -> Result<AudioFileLength> {
+    if sample_rate != CD_SAMPLE_RATE {
+        return Err(anyhow!(
+            "unsupported sample rate {} for {}, expected {}",
+            sample_rate,
+            path.display(),
+            CD_SAMPLE_RATE
+        ));
+    }
+    Ok(AudioFileLength {
+        path: path.to_path_buf(),
+        samples,
+        sample_rate,
+        cd_frames: samples * CD_FRAMES_PER_SECOND / sample_rate,
+    })
+}
+
+fn musicbrainz_disc_id(first_track: u64, last_track: u64, leadout: u64, offsets: &[u64]) -> String {
+    let mut input = format!("{first_track:02X}{last_track:02X}{leadout:08X}");
+    for index in 0..99 {
+        let offset = offsets.get(index).copied().unwrap_or(0);
+        input.push_str(&format!("{offset:08X}"));
+    }
+    let digest = Sha1::digest(input.as_bytes());
+    base64::engine::general_purpose::STANDARD
+        .encode(digest)
+        .replace('+', ".")
+        .replace('/', "_")
+        .replace('=', "-")
+}
+
+#[derive(Debug, Default)]
+struct MusicBrainzRateLimiter {
+    last_request: Mutex<Option<Instant>>,
+}
+
+impl MusicBrainzRateLimiter {
+    async fn until_ready(&self) {
+        let delay = {
+            let mut last_request = self
+                .last_request
+                .lock()
+                .expect("rate limiter mutex poisoned");
+            let now = Instant::now();
+            let delay = last_request
+                .and_then(|last| {
+                    Duration::from_secs(1).checked_sub(now.saturating_duration_since(last))
+                })
+                .unwrap_or_default();
+            *last_request = Some(now + delay);
+            delay
+        };
+        if !delay.is_zero() {
+            sleep(delay).await;
+        }
+    }
+}
+
+fn global_rate_limiter() -> Arc<MusicBrainzRateLimiter> {
+    static LIMITER: OnceLock<Arc<MusicBrainzRateLimiter>> = OnceLock::new();
+    Arc::clone(LIMITER.get_or_init(|| Arc::new(MusicBrainzRateLimiter::default())))
+}
+
+#[derive(Debug, Deserialize)]
+struct MusicBrainzDiscIdResponse {
+    #[serde(default)]
+    releases: Vec<MusicBrainzReleaseResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MusicBrainzReleaseResponse {
+    id: String,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    date: Option<String>,
+    #[serde(default)]
+    country: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    barcode: Option<String>,
+    #[serde(default)]
+    quality: Option<String>,
+    #[serde(default)]
+    media: Vec<MusicBrainzMediumResponse>,
+    #[serde(default, rename = "label-info")]
+    label_info: Vec<serde_json::Value>,
+    #[serde(default, rename = "release-group")]
+    release_group: Option<MusicBrainzReleaseGroupResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MusicBrainzMediumResponse {
+    #[serde(default)]
+    format: Option<String>,
+    #[serde(default, rename = "track-count")]
+    track_count: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MusicBrainzReleaseGroupResponse {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default, rename = "first-release-date")]
+    first_release_date: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::{Arc, Mutex};
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn builds_single_file_toc_and_disc_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wav = tmp.path().join("album.wav");
+        write_wav(&wav, 44_100 * 4);
+        let cue = tmp.path().join("album.cue");
+        fs::write(
+            &cue,
+            r#"FILE "album.wav" WAVE
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+  TRACK 02 AUDIO
+    INDEX 01 00:02:00
+"#,
+        )
+        .unwrap();
+
+        let toc = build_musicbrainz_toc(&[cue]).unwrap();
+
+        assert_eq!(toc.toc, "1 2 450 150 300");
+        assert_eq!(toc.disc_id, musicbrainz_disc_id(1, 2, 450, &[150, 300]));
+        assert!(toc.diagnostic.contains("samples=176400"));
+        assert!(toc.diagnostic.contains("track offsets: [150, 300]"));
+    }
+
+    #[test]
+    fn builds_multi_file_toc_with_cumulative_offsets() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_wav(&tmp.path().join("one.wav"), 44_100 * 2);
+        write_wav(&tmp.path().join("two.wav"), 44_100 * 3);
+        let cue = tmp.path().join("album.cue");
+        fs::write(
+            &cue,
+            r#"FILE "one.wav" WAVE
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+FILE "two.wav" WAVE
+  TRACK 02 AUDIO
+    INDEX 01 00:00:00
+  TRACK 03 AUDIO
+    INDEX 01 00:01:00
+"#,
+        )
+        .unwrap();
+
+        let toc = build_musicbrainz_toc(&[cue]).unwrap();
+
+        assert_eq!(toc.toc, "1 3 525 150 300 375");
+    }
+
+    #[test]
+    fn wav_header_parsing_counts_samples() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wav = tmp.path().join("album.wav");
+        write_wav(&wav, 1234);
+
+        let length = read_wav_file_length(&wav).unwrap();
+
+        assert_eq!(length.samples, 1234);
+        assert_eq!(length.sample_rate, 44_100);
+    }
+
+    #[test]
+    fn flac_length_uses_metaflac_output() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let original_path = std::env::var_os("PATH");
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        fs::create_dir(&bin).unwrap();
+        let metaflac = bin.join("metaflac");
+        fs::write(&metaflac, "#!/bin/sh\nprintf '88200\\n44100\\n'\n").unwrap();
+        fs::set_permissions(&metaflac, fs::Permissions::from_mode(0o755)).unwrap();
+        let flac = tmp.path().join("album.flac");
+        fs::write(&flac, "").unwrap();
+        std::env::set_var("PATH", &bin);
+
+        let length = read_flac_file_length(&flac).unwrap();
+
+        if let Some(path) = original_path {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+        assert_eq!(length.samples, 88_200);
+        assert_eq!(length.sample_rate, 44_100);
+        assert_eq!(length.cd_frames, 150);
+    }
+
+    #[test]
+    fn unsupported_sample_rate_skips_toc() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wav = tmp.path().join("album.wav");
+        write_wav_with_sample_rate(&wav, 48_000, 48_000);
+        let cue = tmp.path().join("album.cue");
+        fs::write(
+            &cue,
+            r#"FILE "album.wav" WAVE
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+"#,
+        )
+        .unwrap();
+
+        let err = build_musicbrainz_toc(&[cue]).unwrap_err().to_string();
+
+        assert!(err.contains("unsupported sample rate 48000"));
+    }
+
+    #[test]
+    fn skips_missing_index_and_non_audio_tracks_with_diagnostics() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_wav(&tmp.path().join("album.wav"), 44_100);
+        let cue = tmp.path().join("album.cue");
+        fs::write(
+            &cue,
+            r#"FILE "album.wav" WAVE
+  TRACK 01 MODE1/2352
+    INDEX 01 00:00:00
+  TRACK 02 AUDIO
+    INDEX 00 00:00:00
+"#,
+        )
+        .unwrap();
+
+        let err = build_musicbrainz_toc(&[cue]).unwrap_err().to_string();
+
+        assert!(err.contains("no audio tracks"));
+    }
+
+    #[tokio::test]
+    async fn adapter_parses_musicbrainz_releases_and_sends_user_agent() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_wav(&tmp.path().join("album.wav"), 44_100);
+        let cue = tmp.path().join("album.cue");
+        fs::write(
+            &cue,
+            r#"FILE "album.wav" WAVE
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+"#,
+        )
+        .unwrap();
+        let body = r#"{"releases":[{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","title":"Album","date":"1984-01-01","country":"DE","status":"Official","barcode":"1234567890123","quality":"normal","media":[{"format":"CD","track-count":10},{"format":"Digital Media","track-count":10}],"label-info":[{"label":{"name":"Label"}}],"release-group":{"id":"11111111-1111-1111-1111-111111111111","title":"Album","first-release-date":"1984"}}]}"#;
+        let (base_url, request) = serve_once(body).await;
+        let lookup = FilesystemMusicBrainzDiscReleaseLookup::new(&MusicBrainzSettings {
+            disc_lookup_enabled: true,
+            base_url,
+            trust_disc_lookup: false,
+            add_missing_release_group_enabled: false,
+        })
+        .with_rate_limiter(Arc::new(MusicBrainzRateLimiter::default()));
+
+        let result = lookup
+            .lookup_musicbrainz_disc_releases(MusicBrainzDiscLookupRequest {
+                cue_paths: vec![cue],
+            })
+            .await
+            .unwrap();
+
+        let MusicBrainzDiscLookupResult::Found {
+            releases,
+            diagnostic,
+        } = result
+        else {
+            panic!("expected MusicBrainz releases");
+        };
+        assert_eq!(releases[0].id, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        assert_eq!(releases[0].media_count, 2);
+        assert_eq!(releases[0].date.as_deref(), Some("1984-01-01"));
+        assert_eq!(releases[0].country.as_deref(), Some("DE"));
+        assert_eq!(releases[0].status.as_deref(), Some("Official"));
+        assert_eq!(releases[0].barcode.as_deref(), Some("1234567890123"));
+        assert_eq!(releases[0].quality.as_deref(), Some("normal"));
+        assert_eq!(releases[0].media_formats, vec!["CD", "Digital Media"]);
+        assert_eq!(releases[0].media_track_counts, vec![10, 10]);
+        assert_eq!(releases[0].label_count, 1);
+        assert_eq!(
+            releases[0].release_group_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+        assert_eq!(releases[0].release_group_title.as_deref(), Some("Album"));
+        assert_eq!(
+            releases[0].release_group_first_release_date.as_deref(),
+            Some("1984")
+        );
+        assert!(diagnostic.contains("barcode_present=true"));
+        assert!(diagnostic.contains("release_group_id=11111111-1111-1111-1111-111111111111"));
+        assert!(diagnostic.contains("formats=[CD, Digital Media]"));
+        assert!(diagnostic.contains("fmt=json"));
+        let request = request.lock().unwrap();
+        assert!(request.contains("GET /ws/2/discid/"));
+        assert!(request.contains("toc="));
+        assert!(request.contains("fmt=json"));
+        assert!(request.contains("inc=artists%2Brecordings%2Brelease-groups"));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("user-agent: splittarr/"));
+    }
+
+    #[tokio::test]
+    async fn adapter_treats_no_releases_as_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_wav(&tmp.path().join("album.wav"), 44_100);
+        let cue = tmp.path().join("album.cue");
+        fs::write(
+            &cue,
+            r#"FILE "album.wav" WAVE
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+"#,
+        )
+        .unwrap();
+        let (base_url, _) = serve_once(r#"{"releases":[]}"#).await;
+        let lookup = FilesystemMusicBrainzDiscReleaseLookup::new(&MusicBrainzSettings {
+            disc_lookup_enabled: true,
+            base_url,
+            trust_disc_lookup: false,
+            add_missing_release_group_enabled: false,
+        })
+        .with_rate_limiter(Arc::new(MusicBrainzRateLimiter::default()));
+
+        let result = lookup
+            .lookup_musicbrainz_disc_releases(MusicBrainzDiscLookupRequest {
+                cue_paths: vec![cue],
+            })
+            .await
+            .unwrap();
+
+        let MusicBrainzDiscLookupResult::NotFound { diagnostic } = result else {
+            panic!("expected no releases");
+        };
+        assert!(diagnostic.contains("MusicBrainz lookup: no releases"));
+    }
+
+    fn write_wav(path: &Path, samples: u64) {
+        write_wav_with_sample_rate(path, samples, 44_100);
+    }
+
+    fn write_wav_with_sample_rate(path: &Path, samples: u64, sample_rate: u32) {
+        let data_size = samples * 4;
+        let riff_size = 36 + data_size;
+        let byte_rate = sample_rate * 4;
+        let mut file = File::create(path).unwrap();
+        file.write_all(b"RIFF").unwrap();
+        file.write_all(&(riff_size as u32).to_le_bytes()).unwrap();
+        file.write_all(b"WAVEfmt ").unwrap();
+        file.write_all(&16_u32.to_le_bytes()).unwrap();
+        file.write_all(&1_u16.to_le_bytes()).unwrap();
+        file.write_all(&2_u16.to_le_bytes()).unwrap();
+        file.write_all(&sample_rate.to_le_bytes()).unwrap();
+        file.write_all(&byte_rate.to_le_bytes()).unwrap();
+        file.write_all(&4_u16.to_le_bytes()).unwrap();
+        file.write_all(&16_u16.to_le_bytes()).unwrap();
+        file.write_all(b"data").unwrap();
+        file.write_all(&(data_size as u32).to_le_bytes()).unwrap();
+        file.write_all(&vec![0_u8; data_size as usize]).unwrap();
+    }
+
+    async fn serve_once(body: &'static str) -> (String, Arc<Mutex<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let request = Arc::new(Mutex::new(String::new()));
+        let shared_request = Arc::clone(&request);
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buffer = [0_u8; 4096];
+            let bytes_read = socket.read(&mut buffer).await.unwrap();
+            *shared_request.lock().unwrap() =
+                String::from_utf8_lossy(&buffer[..bytes_read]).into_owned();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+        (format!("http://{addr}"), request)
+    }
+}

--- a/src/adapters/musicbrainz_api.rs
+++ b/src/adapters/musicbrainz_api.rs
@@ -421,22 +421,23 @@ fn read_wav_file_length(path: &Path) -> Result<AudioFileLength> {
             .map_err(|err| anyhow!("failed to inspect WAV {}: {err}", path.display()))?;
 
         if chunk_id == b"fmt " {
-            let mut fmt = vec![0_u8; chunk_size as usize];
+            if chunk_size < 16 {
+                return Err(anyhow!("unsupported WAV fmt chunk for {}", path.display()));
+            }
+            let mut fmt = [0_u8; 16];
             file.read_exact(&mut fmt)
                 .map_err(|err| anyhow!("failed to read WAV fmt chunk {}: {err}", path.display()))?;
-            if fmt.len() < 16 {
-                return Err(anyhow!("unsupported WAV fmt chunk for {}", path.display()));
+            if chunk_size > 16 {
+                skip_wav_bytes(&mut file, chunk_size - 16, path, "WAV fmt extension")?;
             }
             format_tag = Some(u16::from_le_bytes([fmt[0], fmt[1]]));
             sample_rate = Some(u32::from_le_bytes([fmt[4], fmt[5], fmt[6], fmt[7]]) as u64);
             block_align = Some(u16::from_le_bytes([fmt[12], fmt[13]]) as u64);
         } else if chunk_id == b"data" {
             data_size = Some(chunk_size);
-            file.seek(SeekFrom::Current(chunk_size as i64))
-                .map_err(|err| anyhow!("failed to skip WAV data {}: {err}", path.display()))?;
+            skip_wav_bytes(&mut file, chunk_size, path, "WAV data")?;
         } else {
-            file.seek(SeekFrom::Current(chunk_size as i64))
-                .map_err(|err| anyhow!("failed to skip WAV chunk {}: {err}", path.display()))?;
+            skip_wav_bytes(&mut file, chunk_size, path, "WAV chunk")?;
         }
 
         if chunk_size % 2 == 1 {
@@ -466,6 +467,14 @@ fn read_wav_file_length(path: &Path) -> Result<AudioFileLength> {
     let data_size =
         data_size.ok_or_else(|| anyhow!("WAV data chunk is missing for {}", path.display()))?;
     audio_length(path, data_size / block_align, sample_rate)
+}
+
+fn skip_wav_bytes(file: &mut File, bytes: u64, path: &Path, label: &str) -> Result<()> {
+    let offset = i64::try_from(bytes)
+        .map_err(|_| anyhow!("{label} is too large to skip for {}", path.display()))?;
+    file.seek(SeekFrom::Current(offset))
+        .map_err(|err| anyhow!("failed to skip {label} {}: {err}", path.display()))?;
+    Ok(())
 }
 
 fn audio_length(path: &Path, samples: u64, sample_rate: u64) -> Result<AudioFileLength> {
@@ -652,6 +661,55 @@ FILE "two.wav" WAVE
 
         assert_eq!(length.samples, 1234);
         assert_eq!(length.sample_rate, 44_100);
+    }
+
+    #[test]
+    fn wav_header_parsing_skips_fmt_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wav = tmp.path().join("album.wav");
+        let samples = 1234_u64;
+        let data_size = samples * 4;
+        let riff_size = 38 + data_size;
+        let mut file = File::create(&wav).unwrap();
+        file.write_all(b"RIFF").unwrap();
+        file.write_all(&(riff_size as u32).to_le_bytes()).unwrap();
+        file.write_all(b"WAVEfmt ").unwrap();
+        file.write_all(&18_u32.to_le_bytes()).unwrap();
+        file.write_all(&1_u16.to_le_bytes()).unwrap();
+        file.write_all(&2_u16.to_le_bytes()).unwrap();
+        file.write_all(&44_100_u32.to_le_bytes()).unwrap();
+        file.write_all(&(44_100_u32 * 4).to_le_bytes()).unwrap();
+        file.write_all(&4_u16.to_le_bytes()).unwrap();
+        file.write_all(&16_u16.to_le_bytes()).unwrap();
+        file.write_all(&0_u16.to_le_bytes()).unwrap();
+        file.write_all(b"data").unwrap();
+        file.write_all(&(data_size as u32).to_le_bytes()).unwrap();
+
+        let length = read_wav_file_length(&wav).unwrap();
+
+        assert_eq!(length.samples, samples);
+        assert_eq!(length.sample_rate, 44_100);
+    }
+
+    #[test]
+    fn wav_header_parsing_rejects_huge_malformed_fmt_chunk_without_allocating_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wav = tmp.path().join("album.wav");
+        let mut file = File::create(&wav).unwrap();
+        file.write_all(b"RIFF").unwrap();
+        file.write_all(&36_u32.to_le_bytes()).unwrap();
+        file.write_all(b"WAVEfmt ").unwrap();
+        file.write_all(&u32::MAX.to_le_bytes()).unwrap();
+        file.write_all(&1_u16.to_le_bytes()).unwrap();
+        file.write_all(&2_u16.to_le_bytes()).unwrap();
+        file.write_all(&44_100_u32.to_le_bytes()).unwrap();
+        file.write_all(&(44_100_u32 * 4).to_le_bytes()).unwrap();
+        file.write_all(&4_u16.to_le_bytes()).unwrap();
+        file.write_all(&16_u16.to_le_bytes()).unwrap();
+
+        let err = read_wav_file_length(&wav).unwrap_err().to_string();
+
+        assert!(err.contains("WAV data chunk is missing"));
     }
 
     #[test]

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -283,6 +283,18 @@ impl SqliteDownloadStore {
         Ok(())
     }
 
+    fn record_download_warning_sync(&self, download_id: &str, message: &str) -> Result<()> {
+        let conn = self.connect()?;
+        conn.execute(
+            "UPDATE downloads
+             SET last_error = ?2,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE download_id = ?1",
+            params![download_id, message],
+        )?;
+        Ok(())
+    }
+
     fn get_or_create_cue_sheet_sync(&self, download_id: &str, path: &Path) -> Result<CueSheet> {
         let conn = self.connect()?;
         let path = path.to_string_lossy().to_string();
@@ -525,6 +537,17 @@ impl DownloadStore for SqliteDownloadStore {
         let last_error = last_error.map(str::to_owned);
         tokio::task::spawn_blocking(move || {
             store.mark_download_failed_sync(&download_id, last_error.as_deref())
+        })
+        .await
+        .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn record_download_warning(&self, download_id: &str, message: &str) -> Result<()> {
+        let store = self.clone();
+        let download_id = download_id.to_owned();
+        let message = message.to_owned();
+        tokio::task::spawn_blocking(move || {
+            store.record_download_warning_sync(&download_id, &message)
         })
         .await
         .map_err(|err| anyhow!("blocking task failed to join: {err}"))?

--- a/src/application/cleanup_processed_download.rs
+++ b/src/application/cleanup_processed_download.rs
@@ -1,11 +1,12 @@
 use anyhow::{Context, Result};
 
-use crate::application::ports::{DownloadStore, TrackCleanup};
+use crate::application::ports::{DownloadLog, DownloadStore, TrackCleanup};
 use crate::domain::{TrackCleanupStatus, TrackedDownload};
 
-pub async fn cleanup_processed_download<S: DownloadStore, C: TrackCleanup>(
+pub async fn cleanup_processed_download<S: DownloadStore, C: TrackCleanup, L: DownloadLog>(
     store: &S,
     cleanup: &C,
+    download_log: &L,
     download: &TrackedDownload,
 ) -> Result<()> {
     store
@@ -41,6 +42,14 @@ pub async fn cleanup_processed_download<S: DownloadStore, C: TrackCleanup>(
         .with_context(|| format!("record cleanup results for {}", download.title))?;
 
     if failures.is_empty() {
+        if let Err(err) = download_log.delete_download_log(download).await {
+            let message = format!("download log cleanup failed for {}: {err}", download.title);
+            store
+                .mark_download_failed(&download.download_id, Some(&message))
+                .await
+                .context("mark download failed after log cleanup error")?;
+            return Err(err).context("delete download log");
+        }
         store
             .mark_download_completed(&download.download_id)
             .await
@@ -63,7 +72,7 @@ mod tests {
     use anyhow::Result;
 
     use super::cleanup_processed_download;
-    use crate::application::ports::{DownloadStore, TrackCleanup};
+    use crate::application::ports::{DownloadLog, DownloadStore, TrackCleanup};
     use crate::domain::{
         CueSheet, CueSheetStatus, DownloadLifecycleState, InputFileKind, RecordedTrack,
         TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
@@ -185,10 +194,46 @@ mod tests {
         }
     }
 
+    struct SuccessfulCleanup;
+
+    impl TrackCleanup for SuccessfulCleanup {
+        async fn cleanup_download_tracks(
+            &self,
+            _download: &TrackedDownload,
+        ) -> Result<Vec<TrackCleanupOutcome>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeDownloadLog {
+        deletes: Mutex<usize>,
+        fail_delete: bool,
+    }
+
+    impl DownloadLog for FakeDownloadLog {
+        async fn write_download_log(
+            &self,
+            _download: &TrackedDownload,
+            _content: &str,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn delete_download_log(&self, _download: &TrackedDownload) -> Result<()> {
+            *self.deletes.lock().unwrap() += 1;
+            if self.fail_delete {
+                anyhow::bail!("delete failed");
+            }
+            Ok(())
+        }
+    }
+
     #[tokio::test]
     async fn delete_failed_without_message_marks_download_failed() {
         let store = FakeStore::default();
         let cleanup = FakeCleanup;
+        let log = FakeDownloadLog::default();
         let download = TrackedDownload {
             download_id: "download-1".into(),
             title: "Album".into(),
@@ -211,10 +256,11 @@ mod tests {
             last_error: None,
         };
 
-        cleanup_processed_download(&store, &cleanup, &download)
+        cleanup_processed_download(&store, &cleanup, &log, &download)
             .await
             .unwrap();
 
+        assert_eq!(*log.deletes.lock().unwrap(), 0);
         assert!(store.states.lock().unwrap().contains(&"failed".to_string()));
         assert_eq!(
             store.last_error.lock().unwrap().as_deref(),
@@ -226,6 +272,7 @@ mod tests {
     async fn cleanup_error_marks_download_failed() {
         let store = FakeStore::default();
         let cleanup = FailingCleanup;
+        let log = FakeDownloadLog::default();
         let download = TrackedDownload {
             download_id: "download-1".into(),
             title: "Album".into(),
@@ -248,15 +295,74 @@ mod tests {
             last_error: None,
         };
 
-        let err = cleanup_processed_download(&store, &cleanup, &download)
+        let err = cleanup_processed_download(&store, &cleanup, &log, &download)
             .await
             .unwrap_err();
 
+        assert_eq!(*log.deletes.lock().unwrap(), 0);
         assert!(err.to_string().contains("cleanup failed for Album"));
         assert!(store.states.lock().unwrap().contains(&"failed".to_string()));
         assert_eq!(
             store.last_error.lock().unwrap().as_deref(),
             Some("cleanup failed for Album: filesystem unavailable")
         );
+    }
+
+    #[tokio::test]
+    async fn successful_cleanup_deletes_download_log_before_completion() {
+        let store = FakeStore::default();
+        let cleanup = SuccessfulCleanup;
+        let log = FakeDownloadLog::default();
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Album".into(),
+            "completed".into(),
+            "/downloads/album".into(),
+            "importFailed".into(),
+        );
+
+        cleanup_processed_download(&store, &cleanup, &log, &download)
+            .await
+            .unwrap();
+
+        assert_eq!(*log.deletes.lock().unwrap(), 1);
+        assert!(store
+            .states
+            .lock()
+            .unwrap()
+            .contains(&"completed".to_string()));
+    }
+
+    #[tokio::test]
+    async fn download_log_delete_error_prevents_completion() {
+        let store = FakeStore::default();
+        let cleanup = SuccessfulCleanup;
+        let log = FakeDownloadLog {
+            fail_delete: true,
+            ..Default::default()
+        };
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Album".into(),
+            "completed".into(),
+            "/downloads/album".into(),
+            "importFailed".into(),
+        );
+
+        let err = cleanup_processed_download(&store, &cleanup, &log, &download)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("delete download log"));
+        assert!(store.states.lock().unwrap().contains(&"failed".to_string()));
+        assert_eq!(
+            store.last_error.lock().unwrap().as_deref(),
+            Some("download log cleanup failed for Album: delete failed")
+        );
+        assert!(!store
+            .states
+            .lock()
+            .unwrap()
+            .contains(&"completed".to_string()));
     }
 }

--- a/src/application/cleanup_processed_download.rs
+++ b/src/application/cleanup_processed_download.rs
@@ -44,11 +44,16 @@ pub async fn cleanup_processed_download<S: DownloadStore, C: TrackCleanup, L: Do
     if failures.is_empty() {
         if let Err(err) = download_log.delete_download_log(download).await {
             let message = format!("download log cleanup failed for {}: {err}", download.title);
-            store
-                .mark_download_failed(&download.download_id, Some(&message))
+            eprintln!("{message}");
+            if let Err(warning_err) = store
+                .record_download_warning(&download.download_id, &message)
                 .await
-                .context("mark download failed after log cleanup error")?;
-            return Err(err).context("delete download log");
+            {
+                eprintln!(
+                    "Failed recording download log cleanup warning for {}: {warning_err:#}",
+                    download.title
+                );
+            }
         }
         store
             .mark_download_completed(&download.download_id)
@@ -82,6 +87,7 @@ mod tests {
     struct FakeStore {
         states: Mutex<Vec<String>>,
         last_error: Mutex<Option<String>>,
+        warnings: Mutex<Vec<String>>,
     }
 
     impl DownloadStore for FakeStore {
@@ -125,6 +131,11 @@ mod tests {
         ) -> Result<()> {
             self.states.lock().unwrap().push("failed".into());
             *self.last_error.lock().unwrap() = last_error.map(str::to_owned);
+            Ok(())
+        }
+
+        async fn record_download_warning(&self, _download_id: &str, message: &str) -> Result<()> {
+            self.warnings.lock().unwrap().push(message.to_owned());
             Ok(())
         }
 
@@ -334,7 +345,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn download_log_delete_error_prevents_completion() {
+    async fn download_log_delete_error_records_warning_and_completes() {
         let store = FakeStore::default();
         let cleanup = SuccessfulCleanup;
         let log = FakeDownloadLog {
@@ -349,17 +360,17 @@ mod tests {
             "importFailed".into(),
         );
 
-        let err = cleanup_processed_download(&store, &cleanup, &log, &download)
+        cleanup_processed_download(&store, &cleanup, &log, &download)
             .await
-            .unwrap_err();
+            .unwrap();
 
-        assert!(err.to_string().contains("delete download log"));
-        assert!(store.states.lock().unwrap().contains(&"failed".to_string()));
+        assert_eq!(*log.deletes.lock().unwrap(), 1);
+        assert!(!store.states.lock().unwrap().contains(&"failed".to_string()));
         assert_eq!(
-            store.last_error.lock().unwrap().as_deref(),
+            store.warnings.lock().unwrap().first().map(String::as_str),
             Some("download log cleanup failed for Album: delete failed")
         );
-        assert!(!store
+        assert!(store
             .states
             .lock()
             .unwrap()

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -154,15 +154,30 @@ pub struct CueMetadataHint {
     pub album_title: Option<String>,
     pub performer: Option<String>,
     pub catalog: Option<String>,
+    pub disc_id: Option<String>,
     pub comments: Vec<(String, String)>,
     pub track_count: usize,
+    pub tracks: Vec<CueTrackHint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CueTrackHint {
+    pub number: String,
+    pub title: Option<String>,
+    pub performer: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ManualImportResult {
     Disabled,
-    Started { imported_track_count: usize },
-    Skipped { reason: String },
+    Started {
+        imported_track_count: usize,
+        diagnostic: String,
+    },
+    Skipped {
+        reason: String,
+        diagnostic: String,
+    },
 }
 
 pub trait ManualImportTrigger {
@@ -172,9 +187,133 @@ pub trait ManualImportTrigger {
     ) -> Result<ManualImportResult>;
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MusicBrainzDiscLookupRequest {
+    pub cue_paths: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MusicBrainzDiscLookupResult {
+    Disabled {
+        diagnostic: String,
+    },
+    Found {
+        releases: Vec<MusicBrainzDiscRelease>,
+        diagnostic: String,
+    },
+    NotFound {
+        diagnostic: String,
+    },
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct MusicBrainzDiscRelease {
+    pub id: String,
+    pub title: Option<String>,
+    pub date: Option<String>,
+    pub country: Option<String>,
+    pub status: Option<String>,
+    pub barcode: Option<String>,
+    pub quality: Option<String>,
+    pub media_count: usize,
+    pub media_formats: Vec<String>,
+    pub media_track_counts: Vec<usize>,
+    pub label_count: usize,
+    pub release_group_id: Option<String>,
+    pub release_group_title: Option<String>,
+    pub release_group_first_release_date: Option<String>,
+}
+
+#[async_trait]
+pub trait MusicBrainzDiscReleaseLookup: Send + Sync {
+    async fn lookup_musicbrainz_disc_releases(
+        &self,
+        request: MusicBrainzDiscLookupRequest,
+    ) -> Result<MusicBrainzDiscLookupResult>;
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoopMusicBrainzDiscReleaseLookup;
+
+#[async_trait]
+impl MusicBrainzDiscReleaseLookup for NoopMusicBrainzDiscReleaseLookup {
+    async fn lookup_musicbrainz_disc_releases(
+        &self,
+        _request: MusicBrainzDiscLookupRequest,
+    ) -> Result<MusicBrainzDiscLookupResult> {
+        Ok(MusicBrainzDiscLookupResult::Disabled {
+            diagnostic: "MusicBrainz lookup: disabled\n".into(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscReleaseLookupRequest {
+    pub disc_id: String,
+    pub artist: Option<String>,
+    pub album_title: Option<String>,
+    pub year: Option<i32>,
+    pub track_count: usize,
+    pub track_titles_by_number: Vec<(i64, String)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscReleaseLookupResult {
+    Disabled {
+        diagnostic: String,
+    },
+    Found {
+        candidates: Vec<DiscReleaseCandidate>,
+        diagnostic: String,
+    },
+    NotFound {
+        diagnostic: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscReleaseCandidate {
+    pub category: String,
+    pub entry_id: String,
+    pub disc_id: String,
+    pub artist: Option<String>,
+    pub title: Option<String>,
+    pub year: Option<i32>,
+    pub track_titles: Vec<String>,
+    pub art_ids: Vec<String>,
+}
+
+#[async_trait]
+pub trait DiscReleaseLookup: Send + Sync {
+    async fn lookup_disc_release(
+        &self,
+        request: DiscReleaseLookupRequest,
+    ) -> Result<DiscReleaseLookupResult>;
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoopDiscReleaseLookup;
+
+#[async_trait]
+impl DiscReleaseLookup for NoopDiscReleaseLookup {
+    async fn lookup_disc_release(
+        &self,
+        _request: DiscReleaseLookupRequest,
+    ) -> Result<DiscReleaseLookupResult> {
+        Ok(DiscReleaseLookupResult::Disabled {
+            diagnostic: "GnuDB lookup: disabled\n".into(),
+        })
+    }
+}
+
 pub trait TrackCleanup {
     async fn cleanup_download_tracks(
         &self,
         download: &TrackedDownload,
     ) -> Result<Vec<TrackCleanupOutcome>>;
+}
+
+pub trait DownloadLog {
+    async fn write_download_log(&self, download: &TrackedDownload, content: &str) -> Result<()>;
+    async fn delete_download_log(&self, download: &TrackedDownload) -> Result<()>;
 }

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -55,6 +55,9 @@ pub trait DownloadStore {
     async fn mark_download_completed(&self, download_id: &str) -> Result<()>;
     async fn mark_download_failed(&self, download_id: &str, last_error: Option<&str>)
         -> Result<()>;
+    async fn record_download_warning(&self, _download_id: &str, _message: &str) -> Result<()> {
+        Ok(())
+    }
     async fn get_or_create_cue_sheet(&self, download_id: &str, path: &Path) -> Result<CueSheet>;
     async fn record_input_file(
         &self,
@@ -136,6 +139,37 @@ pub trait CueInputInspector {
 
 pub trait CueSplitter {
     async fn split_cue(&self, cue_path: &Path) -> Result<SplitOutcome>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManualImportRequest {
+    pub download: TrackedDownload,
+    pub generated_tracks: Vec<PathBuf>,
+    pub cue_hints: Vec<CueMetadataHint>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CueMetadataHint {
+    pub path: PathBuf,
+    pub album_title: Option<String>,
+    pub performer: Option<String>,
+    pub catalog: Option<String>,
+    pub comments: Vec<(String, String)>,
+    pub track_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ManualImportResult {
+    Disabled,
+    Started { imported_track_count: usize },
+    Skipped { reason: String },
+}
+
+pub trait ManualImportTrigger {
+    async fn trigger_manual_import(
+        &self,
+        request: ManualImportRequest,
+    ) -> Result<ManualImportResult>;
 }
 
 pub trait TrackCleanup {

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -1,8 +1,12 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
+use rcue::parser::parse_from_file;
 
-use crate::application::ports::{CueInputInspector, CueScanner, CueSplitter, DownloadStore};
+use crate::application::ports::{
+    CueInputInspector, CueMetadataHint, CueScanner, CueSplitter, DownloadStore,
+    ManualImportRequest, ManualImportTrigger,
+};
 use crate::domain::{
     CueSheet, CueSheetStatus, FailedImportCandidate, InputFileKind, RecordedTrack, SplitOutcome,
     SplitStatus, TrackedDownload,
@@ -40,11 +44,12 @@ pub async fn register_failed_imports<S: DownloadStore>(
     Ok(())
 }
 
-pub async fn process_tracked_download<S, C, I, P>(
+pub async fn process_tracked_download<S, C, I, P, M>(
     store: &S,
     scanner: &C,
     inspector: &I,
     splitter: &P,
+    manual_import: &M,
     download: TrackedDownload,
 ) -> Result<()>
 where
@@ -52,6 +57,7 @@ where
     C: CueScanner,
     I: CueInputInspector,
     P: CueSplitter,
+    M: ManualImportTrigger,
 {
     store
         .mark_download_processing(&download.download_id)
@@ -80,8 +86,11 @@ where
 
     let mut all_cues_complete = true;
     let mut failures = Vec::new();
+    let mut generated_tracks = Vec::new();
+    let mut cue_hints = Vec::new();
 
     for cue_path in scan.cue_files {
+        cue_hints.push(cue_metadata_hint(&cue_path));
         let cue_sheet = store
             .get_or_create_cue_sheet(&download.download_id, &cue_path)
             .await?;
@@ -100,7 +109,9 @@ where
 
         match splitter.split_cue(&cue_path).await {
             Ok(result) => {
+                let tracks = result.tracks.clone();
                 store_split_result(store, inspector, &cue_sheet, result).await?;
+                generated_tracks.extend(tracks);
             }
             Err(err) => {
                 all_cues_complete = false;
@@ -127,6 +138,26 @@ where
         store
             .mark_download_awaiting_import(&download.download_id)
             .await?;
+        if !generated_tracks.is_empty() {
+            let request = ManualImportRequest {
+                download: download.clone(),
+                generated_tracks,
+                cue_hints,
+            };
+            match manual_import.trigger_manual_import(request).await {
+                Ok(result) => println!("Manual import for {}: {result:?}", download.title),
+                Err(err) => {
+                    let message = format!("manual import trigger failed: {err}");
+                    eprintln!(
+                        "Manual import trigger failed for {}: {err:#}",
+                        download.title
+                    );
+                    store
+                        .record_download_warning(&download.download_id, &message)
+                        .await?;
+                }
+            }
+        }
     } else {
         store
             .mark_download_failed(&download.download_id, error_message.as_deref())
@@ -135,6 +166,31 @@ where
 
     println!("Done processing {}", download.title);
     Ok(())
+}
+
+fn cue_metadata_hint(cue_path: &Path) -> CueMetadataHint {
+    let cue = cue_path
+        .to_str()
+        .and_then(|path| parse_from_file(path, false).ok());
+    let Some(cue) = cue else {
+        return CueMetadataHint {
+            path: cue_path.to_path_buf(),
+            album_title: None,
+            performer: None,
+            catalog: None,
+            comments: Vec::new(),
+            track_count: 0,
+        };
+    };
+
+    CueMetadataHint {
+        path: cue_path.to_path_buf(),
+        album_title: cue.title,
+        performer: cue.performer,
+        catalog: cue.catalog,
+        comments: cue.comments,
+        track_count: cue.files.iter().map(|file| file.tracks.len()).sum(),
+    }
 }
 
 async fn store_split_result<S: DownloadStore, I: CueInputInspector>(
@@ -219,7 +275,7 @@ mod tests {
     use super::process_tracked_download;
     use crate::application::ports::{
         CueInputInspector, CueInputSnapshot, CueReferencedAudioInput, CueScanner, CueSplitter,
-        DownloadStore,
+        DownloadStore, ManualImportRequest, ManualImportResult, ManualImportTrigger,
     };
     use crate::domain::{
         CueSheet, CueSheetStatus, DiscoveredCueSheets, InputFileKind, RecordedTrack, SplitOutcome,
@@ -233,6 +289,7 @@ mod tests {
         recorded_cues: Mutex<Vec<String>>,
         recorded_input_files: Mutex<Vec<(String, InputFileKind)>>,
         recorded_tracks: Mutex<Vec<String>>,
+        warnings: Mutex<Vec<String>>,
     }
 
     impl DownloadStore for FakeStore {
@@ -276,6 +333,12 @@ mod tests {
         ) -> Result<()> {
             self.states.lock().unwrap().push("failed".into());
             *self.last_error.lock().unwrap() = last_error.map(str::to_owned);
+            Ok(())
+        }
+
+        async fn record_download_warning(&self, _download_id: &str, message: &str) -> Result<()> {
+            self.warnings.lock().unwrap().push(message.to_owned());
+            *self.last_error.lock().unwrap() = Some(message.to_owned());
             Ok(())
         }
 
@@ -417,6 +480,27 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct FakeManualImport {
+        calls: Mutex<Vec<ManualImportRequest>>,
+        fail: bool,
+    }
+
+    impl ManualImportTrigger for FakeManualImport {
+        async fn trigger_manual_import(
+            &self,
+            request: ManualImportRequest,
+        ) -> Result<ManualImportResult> {
+            self.calls.lock().unwrap().push(request);
+            if self.fail {
+                return Err(anyhow::anyhow!("lidarr is unavailable"));
+            }
+            Ok(ManualImportResult::Started {
+                imported_track_count: 1,
+            })
+        }
+    }
+
     #[tokio::test]
     async fn processes_file_output_path_using_parent_directory_and_matching_cue() {
         let tmp = tempdir().unwrap();
@@ -440,6 +524,7 @@ mod tests {
         let splitter = FakeSplitter {
             calls: Mutex::new(Vec::new()),
         };
+        let manual_import = FakeManualImport::default();
         let download = TrackedDownload::pending(
             "download-1".into(),
             "Single".into(),
@@ -448,9 +533,16 @@ mod tests {
             "importFailed".into(),
         );
 
-        process_tracked_download(&store, &scanner, &inspector, &splitter, download)
-            .await
-            .unwrap();
+        process_tracked_download(
+            &store,
+            &scanner,
+            &inspector,
+            &splitter,
+            &manual_import,
+            download,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             scanner.roots.lock().unwrap().as_slice(),
@@ -462,6 +554,7 @@ mod tests {
             .lock()
             .unwrap()
             .contains(&"awaiting_import".to_string()));
+        assert_eq!(manual_import.calls.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]
@@ -487,6 +580,7 @@ mod tests {
         let splitter = FakeSplitter {
             calls: Mutex::new(Vec::new()),
         };
+        let manual_import = FakeManualImport::default();
         let download = TrackedDownload::pending(
             "download-1".into(),
             "Single".into(),
@@ -495,11 +589,19 @@ mod tests {
             "importFailed".into(),
         );
 
-        process_tracked_download(&store, &scanner, &inspector, &splitter, download)
-            .await
-            .unwrap();
+        process_tracked_download(
+            &store,
+            &scanner,
+            &inspector,
+            &splitter,
+            &manual_import,
+            download,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(splitter.calls.lock().unwrap().len(), 0);
+        assert_eq!(manual_import.calls.lock().unwrap().len(), 0);
         assert_eq!(
             store.last_error.lock().unwrap().as_deref(),
             Some("no cue files found")
@@ -537,6 +639,7 @@ mod tests {
         let splitter = FakeSplitter {
             calls: Mutex::new(Vec::new()),
         };
+        let manual_import = FakeManualImport::default();
         let download = TrackedDownload::pending(
             "download-1".into(),
             "Single".into(),
@@ -545,9 +648,16 @@ mod tests {
             "importFailed".into(),
         );
 
-        process_tracked_download(&store, &scanner, &inspector, &splitter, download)
-            .await
-            .unwrap();
+        process_tracked_download(
+            &store,
+            &scanner,
+            &inspector,
+            &splitter,
+            &manual_import,
+            download,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(splitter.calls.lock().unwrap().as_slice(), &[target_cue]);
     }
@@ -569,6 +679,10 @@ mod tests {
         let splitter = FakeSplitter {
             calls: Mutex::new(Vec::new()),
         };
+        let manual_import = FakeManualImport {
+            fail: true,
+            ..Default::default()
+        };
         let download = TrackedDownload::pending(
             "download-1".into(),
             "Broken".into(),
@@ -577,9 +691,16 @@ mod tests {
             "importFailed".into(),
         );
 
-        process_tracked_download(&store, &scanner, &inspector, &splitter, download)
-            .await
-            .unwrap();
+        process_tracked_download(
+            &store,
+            &scanner,
+            &inspector,
+            &splitter,
+            &manual_import,
+            download,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             splitter.calls.lock().unwrap().as_slice(),
@@ -594,5 +715,9 @@ mod tests {
             .lock()
             .unwrap()
             .contains(&"awaiting_import".to_string()));
+        assert_eq!(
+            store.warnings.lock().unwrap().as_slice(),
+            &["manual import trigger failed: lidarr is unavailable"]
+        );
     }
 }

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -4,8 +4,8 @@ use anyhow::{anyhow, Result};
 use rcue::parser::parse_from_file;
 
 use crate::application::ports::{
-    CueInputInspector, CueMetadataHint, CueScanner, CueSplitter, DownloadStore,
-    ManualImportRequest, ManualImportTrigger,
+    CueInputInspector, CueInputSnapshot, CueMetadataHint, CueScanner, CueSplitter, DownloadLog,
+    DownloadStore, ManualImportRequest, ManualImportResult, ManualImportTrigger,
 };
 use crate::domain::{
     CueSheet, CueSheetStatus, FailedImportCandidate, InputFileKind, RecordedTrack, SplitOutcome,
@@ -44,12 +44,13 @@ pub async fn register_failed_imports<S: DownloadStore>(
     Ok(())
 }
 
-pub async fn process_tracked_download<S, C, I, P, M>(
+pub async fn process_tracked_download<S, C, I, P, M, L>(
     store: &S,
     scanner: &C,
     inspector: &I,
     splitter: &P,
     manual_import: &M,
+    download_log: &L,
     download: TrackedDownload,
 ) -> Result<()>
 where
@@ -58,12 +59,17 @@ where
     I: CueInputInspector,
     P: CueSplitter,
     M: ManualImportTrigger,
+    L: DownloadLog,
 {
     store
         .mark_download_processing(&download.download_id)
         .await?;
+    let mut log = initial_download_log(&download);
+    write_log_best_effort(download_log, &download, &log).await;
+
     let output_path = PathBuf::from(&download.output_path);
     let scan_root = scan_root_for(&output_path)?;
+    append_log_line(&mut log, format!("Scan root: {}", scan_root.display()));
     let mut scan = scanner.find_cue_sheets(&scan_root).await?;
 
     if output_path.is_file() {
@@ -72,12 +78,23 @@ where
             .await?;
     }
 
+    append_log_line(
+        &mut log,
+        format!("Discovered cue sheets: {}", scan.cue_files.len()),
+    );
+    for cue_path in &scan.cue_files {
+        append_log_line(&mut log, format!("  - {}", cue_path.display()));
+    }
     for error in &scan.errors {
         eprintln!("Scan warning for {}: {error}", download.title);
+        append_log_line(&mut log, format!("Scan warning: {error}"));
     }
 
     if scan.cue_files.is_empty() {
         eprintln!("Failed processing {}: no cue files found", download.title);
+        append_log_line(&mut log, "Final state: failed");
+        append_log_line(&mut log, "Failure: no cue files found");
+        write_log_best_effort(download_log, &download, &log).await;
         store
             .mark_download_failed(&download.download_id, Some("no cue files found"))
             .await?;
@@ -91,10 +108,12 @@ where
 
     for cue_path in scan.cue_files {
         cue_hints.push(cue_metadata_hint(&cue_path));
+        append_log_line(&mut log, "");
+        append_log_line(&mut log, format!("Cue: {}", cue_path.display()));
         let cue_sheet = store
             .get_or_create_cue_sheet(&download.download_id, &cue_path)
             .await?;
-        snapshot_input_files(
+        let snapshot = snapshot_input_files(
             store,
             inspector,
             &download.download_id,
@@ -102,8 +121,17 @@ where
             &cue_path,
         )
         .await?;
+        append_input_snapshot(&mut log, &snapshot);
 
         if cue_sheet.status.is_terminal_success() {
+            append_log_line(
+                &mut log,
+                format!(
+                    "Split status: already {:?}; using {} recorded track(s)",
+                    cue_sheet.status,
+                    cue_sheet.tracks.len()
+                ),
+            );
             generated_tracks.extend(
                 cue_sheet
                     .tracks
@@ -116,6 +144,20 @@ where
         match splitter.split_cue(&cue_path).await {
             Ok(result) => {
                 let tracks = result.tracks.clone();
+                append_log_line(
+                    &mut log,
+                    format!(
+                        "Split status: {:?}; generated {} track(s)",
+                        result.status,
+                        result.tracks.len()
+                    ),
+                );
+                if let Some(message) = &result.message {
+                    append_log_line(&mut log, format!("Split message: {message}"));
+                }
+                for track in &tracks {
+                    append_log_line(&mut log, format!("  generated: {}", track.display()));
+                }
                 store_split_result(store, inspector, &cue_sheet, result).await?;
                 generated_tracks.extend(tracks);
             }
@@ -128,6 +170,7 @@ where
                     cue_path.display()
                 );
                 failures.push(format!("{}: {message}", cue_path.display()));
+                append_log_line(&mut log, format!("Split failed: {message}"));
                 store
                     .record_cue_result(&cue_sheet, CueSheetStatus::Failed, Some(&message), &[])
                     .await?;
@@ -144,6 +187,12 @@ where
         store
             .mark_download_awaiting_import(&download.download_id)
             .await?;
+        append_log_line(&mut log, "");
+        append_log_line(&mut log, "Final processing state: awaiting_import");
+        append_log_line(
+            &mut log,
+            format!("Generated tracks total: {}", generated_tracks.len()),
+        );
         if !generated_tracks.is_empty() {
             let request = ManualImportRequest {
                 download: download.clone(),
@@ -151,27 +200,127 @@ where
                 cue_hints,
             };
             match manual_import.trigger_manual_import(request).await {
-                Ok(result) => println!("Manual import for {}: {result:?}", download.title),
+                Ok(result) => {
+                    println!("Manual import for {}: {result:?}", download.title);
+                    append_manual_import_result(&mut log, &result);
+                }
                 Err(err) => {
                     let message = format!("manual import trigger failed: {err}");
                     eprintln!(
                         "Manual import trigger failed for {}: {err:#}",
                         download.title
                     );
+                    append_log_line(&mut log, "");
+                    append_log_line(&mut log, "Manual import: failed");
+                    append_log_line(&mut log, format!("{err:#}"));
                     store
                         .record_download_warning(&download.download_id, &message)
                         .await?;
                 }
             }
+        } else {
+            append_log_line(
+                &mut log,
+                "Manual import: skipped because no generated tracks exist",
+            );
         }
     } else {
+        append_log_line(&mut log, "");
+        append_log_line(&mut log, "Final processing state: failed");
+        if let Some(error_message) = &error_message {
+            append_log_line(&mut log, format!("Failures: {error_message}"));
+        }
         store
             .mark_download_failed(&download.download_id, error_message.as_deref())
             .await?;
     }
 
+    write_log_best_effort(download_log, &download, &log).await;
     println!("Done processing {}", download.title);
     Ok(())
+}
+
+fn initial_download_log(download: &TrackedDownload) -> String {
+    let mut log = String::new();
+    append_log_line(&mut log, "Splittarr processing log");
+    append_log_line(&mut log, format!("Download ID: {}", download.download_id));
+    append_log_line(&mut log, format!("Title: {}", download.title));
+    append_log_line(&mut log, format!("Lidarr status: {}", download.status));
+    append_log_line(
+        &mut log,
+        format!("Tracked state: {}", download.tracked_download_state),
+    );
+    append_log_line(&mut log, format!("Output path: {}", download.output_path));
+    append_log_line(&mut log, "");
+    log
+}
+
+fn append_input_snapshot(log: &mut String, snapshot: &CueInputSnapshot) {
+    append_log_line(
+        log,
+        format!("Cue size bytes: {}", optional_i64(snapshot.cue_size_bytes)),
+    );
+    append_log_line(
+        log,
+        format!("Referenced audio inputs: {}", snapshot.audio_inputs.len()),
+    );
+    for input in &snapshot.audio_inputs {
+        append_log_line(
+            log,
+            format!(
+                "  audio: {} ({} bytes)",
+                input.path.display(),
+                optional_i64(input.size_bytes)
+            ),
+        );
+    }
+}
+
+fn append_manual_import_result(log: &mut String, result: &ManualImportResult) {
+    append_log_line(log, "");
+    match result {
+        ManualImportResult::Disabled => {
+            append_log_line(log, "Manual import: disabled");
+        }
+        ManualImportResult::Started {
+            imported_track_count,
+            diagnostic,
+        } => {
+            append_log_line(
+                log,
+                format!("Manual import: started for {imported_track_count} track(s)"),
+            );
+            append_log_line(log, diagnostic);
+        }
+        ManualImportResult::Skipped { reason, diagnostic } => {
+            append_log_line(log, format!("Manual import: skipped: {reason}"));
+            append_log_line(log, diagnostic);
+        }
+    }
+}
+
+fn append_log_line(log: &mut String, line: impl AsRef<str>) {
+    log.push_str(line.as_ref());
+    log.push('\n');
+}
+
+fn optional_i64(value: Option<i64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+async fn write_log_best_effort<L: DownloadLog>(
+    download_log: &L,
+    download: &TrackedDownload,
+    content: &str,
+) {
+    if let Err(err) = download_log.write_download_log(download, content).await {
+        eprintln!(
+            "Failed writing download log for {}: {err:#}",
+            download.title
+        );
+    }
 }
 
 fn cue_metadata_hint(cue_path: &Path) -> CueMetadataHint {
@@ -182,19 +331,42 @@ fn cue_metadata_hint(cue_path: &Path) -> CueMetadataHint {
             album_title: None,
             performer: None,
             catalog: None,
+            disc_id: None,
             comments: Vec::new(),
             track_count: 0,
+            tracks: Vec::new(),
         };
     };
+
+    let tracks = cue
+        .files
+        .iter()
+        .flat_map(|file| file.tracks.iter())
+        .map(|track| crate::application::ports::CueTrackHint {
+            number: track.no.clone(),
+            title: track.title.clone(),
+            performer: track.performer.clone(),
+        })
+        .collect::<Vec<_>>();
 
     CueMetadataHint {
         path: cue_path.to_path_buf(),
         album_title: cue.title,
         performer: cue.performer,
         catalog: cue.catalog,
+        disc_id: cue_comment_value(&cue.comments, "DISCID").map(str::to_owned),
         comments: cue.comments,
         track_count: cue.files.iter().map(|file| file.tracks.len()).sum(),
+        tracks,
     }
+}
+
+fn cue_comment_value<'a>(comments: &'a [(String, String)], key: &str) -> Option<&'a str> {
+    comments
+        .iter()
+        .find(|(comment_key, _)| comment_key.eq_ignore_ascii_case(key))
+        .map(|(_, value)| value.trim())
+        .filter(|value| !value.is_empty())
 }
 
 async fn store_split_result<S: DownloadStore, I: CueInputInspector>(
@@ -225,7 +397,7 @@ async fn snapshot_input_files<S: DownloadStore, I: CueInputInspector>(
     download_id: &str,
     cue_sheet: &CueSheet,
     cue_path: &Path,
-) -> Result<()> {
+) -> Result<CueInputSnapshot> {
     let snapshot = inspector.snapshot_inputs(cue_path).await?;
     store
         .record_input_file(
@@ -237,7 +409,7 @@ async fn snapshot_input_files<S: DownloadStore, I: CueInputInspector>(
         )
         .await?;
 
-    for input in snapshot.audio_inputs {
+    for input in &snapshot.audio_inputs {
         store
             .record_input_file(
                 download_id,
@@ -249,7 +421,7 @@ async fn snapshot_input_files<S: DownloadStore, I: CueInputInspector>(
             .await?;
     }
 
-    Ok(())
+    Ok(snapshot)
 }
 
 fn scan_root_for(output_path: &Path) -> Result<PathBuf> {
@@ -279,7 +451,7 @@ mod tests {
     use super::process_tracked_download;
     use crate::application::ports::{
         CueInputInspector, CueInputSnapshot, CueReferencedAudioInput, CueScanner, CueSplitter,
-        DownloadStore, ManualImportRequest, ManualImportResult, ManualImportTrigger,
+        DownloadLog, DownloadStore, ManualImportRequest, ManualImportResult, ManualImportTrigger,
     };
     use crate::domain::{
         CueSheet, CueSheetStatus, DiscoveredCueSheets, GeneratedTrack, InputFileKind,
@@ -514,7 +686,28 @@ mod tests {
             }
             Ok(ManualImportResult::Started {
                 imported_track_count: 1,
+                diagnostic: "fake manual import diagnostic".into(),
             })
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeDownloadLog {
+        writes: Mutex<Vec<String>>,
+    }
+
+    impl DownloadLog for FakeDownloadLog {
+        async fn write_download_log(
+            &self,
+            _download: &TrackedDownload,
+            content: &str,
+        ) -> Result<()> {
+            self.writes.lock().unwrap().push(content.to_owned());
+            Ok(())
+        }
+
+        async fn delete_download_log(&self, _download: &TrackedDownload) -> Result<()> {
+            Ok(())
         }
     }
 
@@ -542,6 +735,7 @@ mod tests {
             calls: Mutex::new(Vec::new()),
         };
         let manual_import = FakeManualImport::default();
+        let download_log = FakeDownloadLog::default();
         let download = TrackedDownload::pending(
             "download-1".into(),
             "Single".into(),
@@ -556,6 +750,7 @@ mod tests {
             &inspector,
             &splitter,
             &manual_import,
+            &download_log,
             download,
         )
         .await
@@ -572,6 +767,11 @@ mod tests {
             .unwrap()
             .contains(&"awaiting_import".to_string()));
         assert_eq!(manual_import.calls.lock().unwrap().len(), 1);
+        let log_writes = download_log.writes.lock().unwrap();
+        assert!(log_writes
+            .last()
+            .unwrap()
+            .contains("fake manual import diagnostic"));
     }
 
     #[tokio::test]
@@ -598,6 +798,7 @@ mod tests {
             calls: Mutex::new(Vec::new()),
         };
         let manual_import = FakeManualImport::default();
+        let download_log = FakeDownloadLog::default();
         let download = TrackedDownload::pending(
             "download-1".into(),
             "Single".into(),
@@ -612,6 +813,7 @@ mod tests {
             &inspector,
             &splitter,
             &manual_import,
+            &download_log,
             download,
         )
         .await
@@ -623,6 +825,13 @@ mod tests {
             store.last_error.lock().unwrap().as_deref(),
             Some("no cue files found")
         );
+        assert!(download_log
+            .writes
+            .lock()
+            .unwrap()
+            .last()
+            .unwrap()
+            .contains("Failure: no cue files found"));
     }
 
     #[tokio::test]
@@ -657,6 +866,7 @@ mod tests {
             calls: Mutex::new(Vec::new()),
         };
         let manual_import = FakeManualImport::default();
+        let download_log = FakeDownloadLog::default();
         let download = TrackedDownload::pending(
             "download-1".into(),
             "Single".into(),
@@ -671,6 +881,7 @@ mod tests {
             &inspector,
             &splitter,
             &manual_import,
+            &download_log,
             download,
         )
         .await
@@ -723,6 +934,7 @@ mod tests {
             calls: Mutex::new(Vec::new()),
         };
         let manual_import = FakeManualImport::default();
+        let download_log = FakeDownloadLog::default();
         let download = TrackedDownload::pending(
             "download-1".into(),
             "Album".into(),
@@ -737,6 +949,7 @@ mod tests {
             &inspector,
             &splitter,
             &manual_import,
+            &download_log,
             download,
         )
         .await
@@ -770,6 +983,7 @@ mod tests {
             fail: true,
             ..Default::default()
         };
+        let download_log = FakeDownloadLog::default();
         let download = TrackedDownload::pending(
             "download-1".into(),
             "Broken".into(),
@@ -784,6 +998,7 @@ mod tests {
             &inspector,
             &splitter,
             &manual_import,
+            &download_log,
             download,
         )
         .await
@@ -806,5 +1021,12 @@ mod tests {
             store.warnings.lock().unwrap().as_slice(),
             &["manual import trigger failed: lidarr is unavailable"]
         );
+        assert!(download_log
+            .writes
+            .lock()
+            .unwrap()
+            .last()
+            .unwrap()
+            .contains("Manual import: failed"));
     }
 }

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -175,9 +175,7 @@ where
 }
 
 fn cue_metadata_hint(cue_path: &Path) -> CueMetadataHint {
-    let cue = cue_path
-        .to_str()
-        .and_then(|path| parse_from_file(path, false).ok());
+    let cue = parse_from_file(&cue_path.to_string_lossy(), false).ok();
     let Some(cue) = cue else {
         return CueMetadataHint {
             path: cue_path.to_path_buf(),

--- a/src/application/process_tracked_download.rs
+++ b/src/application/process_tracked_download.rs
@@ -104,6 +104,12 @@ where
         .await?;
 
         if cue_sheet.status.is_terminal_success() {
+            generated_tracks.extend(
+                cue_sheet
+                    .tracks
+                    .iter()
+                    .map(|track| PathBuf::from(&track.path)),
+            );
             continue;
         }
 
@@ -278,8 +284,8 @@ mod tests {
         DownloadStore, ManualImportRequest, ManualImportResult, ManualImportTrigger,
     };
     use crate::domain::{
-        CueSheet, CueSheetStatus, DiscoveredCueSheets, InputFileKind, RecordedTrack, SplitOutcome,
-        SplitStatus, TrackCleanupStatus, TrackedDownload,
+        CueSheet, CueSheetStatus, DiscoveredCueSheets, GeneratedTrack, InputFileKind,
+        RecordedTrack, SplitOutcome, SplitStatus, TrackCleanupStatus, TrackedDownload,
     };
 
     #[derive(Default)]
@@ -289,6 +295,7 @@ mod tests {
         recorded_cues: Mutex<Vec<String>>,
         recorded_input_files: Mutex<Vec<(String, InputFileKind)>>,
         recorded_tracks: Mutex<Vec<String>>,
+        cue_sheets: Mutex<Vec<CueSheet>>,
         warnings: Mutex<Vec<String>>,
     }
 
@@ -351,6 +358,18 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push(path.to_string_lossy().to_string());
+            if let Some(cue_sheet) = self
+                .cue_sheets
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|cue_sheet| {
+                    cue_sheet.download_id == download_id && cue_sheet.path == path.to_string_lossy()
+                })
+                .cloned()
+            {
+                return Ok(cue_sheet);
+            }
             Ok(CueSheet {
                 id: format!("cue:{}", path.display()),
                 download_id: download_id.to_owned(),
@@ -663,6 +682,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manual_import_includes_tracks_from_already_split_cues() {
+        let tmp = tempdir().unwrap();
+        let cue_path = tmp.path().join("album.cue");
+        let audio_path = tmp.path().join("album.flac");
+        let recorded_track = tmp.path().join("01 - Track.flac");
+        fs::write(&audio_path, b"audio").unwrap();
+        fs::write(&recorded_track, b"track").unwrap();
+        fs::write(
+            &cue_path,
+            "FILE \"album.flac\" WAVE\n  TRACK 01 AUDIO\n    TITLE \"Track\"\n    INDEX 01 00:00:00\n",
+        )
+        .unwrap();
+
+        let store = FakeStore::default();
+        store.cue_sheets.lock().unwrap().push(CueSheet {
+            id: "cue-1".into(),
+            download_id: "download-1".into(),
+            path: cue_path.to_string_lossy().to_string(),
+            status: CueSheetStatus::Split,
+            message: None,
+            updated_at: "now".into(),
+            tracks: vec![GeneratedTrack {
+                id: "track-1".into(),
+                cue_sheet_id: "cue-1".into(),
+                download_id: "download-1".into(),
+                path: recorded_track.to_string_lossy().to_string(),
+                size_bytes: Some(5),
+                cleanup_status: TrackCleanupStatus::Pending,
+                cleanup_message: None,
+                deleted_at: None,
+            }],
+        });
+        let scanner = FakeScanner {
+            roots: Mutex::new(Vec::new()),
+            cue_files: vec![cue_path],
+        };
+        let inspector = FakeInspector {
+            matches: Mutex::new(Vec::new()),
+        };
+        let splitter = FakeSplitter {
+            calls: Mutex::new(Vec::new()),
+        };
+        let manual_import = FakeManualImport::default();
+        let download = TrackedDownload::pending(
+            "download-1".into(),
+            "Album".into(),
+            "completed".into(),
+            tmp.path().to_string_lossy().to_string(),
+            "importFailed".into(),
+        );
+
+        process_tracked_download(
+            &store,
+            &scanner,
+            &inspector,
+            &splitter,
+            &manual_import,
+            download,
+        )
+        .await
+        .unwrap();
+
+        assert!(splitter.calls.lock().unwrap().is_empty());
+        let calls = manual_import.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].generated_tracks, vec![recorded_track]);
+        assert_eq!(calls[0].cue_hints[0].track_count, 1);
+    }
+
+    #[tokio::test]
     async fn invalid_cue_snapshot_records_cue_file_and_continues_processing() {
         let tmp = tempdir().unwrap();
         let cue_path = tmp.path().join("broken.cue");
@@ -704,7 +793,7 @@ mod tests {
 
         assert_eq!(
             splitter.calls.lock().unwrap().as_slice(),
-            &[cue_path.clone()]
+            std::slice::from_ref(&cue_path)
         );
         assert_eq!(
             store.recorded_input_files.lock().unwrap().as_slice(),

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -6,51 +6,60 @@ use chrono::prelude::*;
 use crate::application::cleanup_processed_download::cleanup_processed_download;
 use crate::application::monitor_download_queue::classify_downloads;
 use crate::application::ports::{
-    CueInputInspector, CueScanner, CueSplitter, DownloadStore, QueueSource, TrackCleanup,
+    CueInputInspector, CueScanner, CueSplitter, DownloadStore, ManualImportTrigger, QueueSource,
+    TrackCleanup,
 };
 use crate::application::process_tracked_download::{
     process_tracked_download, register_failed_imports,
 };
 
-pub struct MonitorService<Q, S, C, I, P, X> {
+pub struct MonitorService<Q, S, C, I, P, M, X> {
     queue_source: Q,
     download_store: S,
     cue_scanner: C,
     cue_input_inspector: I,
     cue_splitter: P,
+    manual_import: M,
     track_cleanup: X,
     check_frequency_seconds: u64,
 }
 
-impl<Q, S, C, I, P, X> MonitorService<Q, S, C, I, P, X> {
+pub struct ProcessingAdapters<C, I, P, M, X> {
+    pub cue_scanner: C,
+    pub cue_input_inspector: I,
+    pub cue_splitter: P,
+    pub manual_import: M,
+    pub track_cleanup: X,
+}
+
+impl<Q, S, C, I, P, M, X> MonitorService<Q, S, C, I, P, M, X> {
     pub fn new(
         queue_source: Q,
         download_store: S,
-        cue_scanner: C,
-        cue_input_inspector: I,
-        cue_splitter: P,
-        track_cleanup: X,
+        adapters: ProcessingAdapters<C, I, P, M, X>,
         check_frequency_seconds: u64,
     ) -> Self {
         Self {
             queue_source,
             download_store,
-            cue_scanner,
-            cue_input_inspector,
-            cue_splitter,
-            track_cleanup,
+            cue_scanner: adapters.cue_scanner,
+            cue_input_inspector: adapters.cue_input_inspector,
+            cue_splitter: adapters.cue_splitter,
+            manual_import: adapters.manual_import,
+            track_cleanup: adapters.track_cleanup,
             check_frequency_seconds,
         }
     }
 }
 
-impl<Q, S, C, I, P, X> MonitorService<Q, S, C, I, P, X>
+impl<Q, S, C, I, P, M, X> MonitorService<Q, S, C, I, P, M, X>
 where
     Q: QueueSource,
     S: DownloadStore,
     C: CueScanner,
     I: CueInputInspector,
     P: CueSplitter,
+    M: ManualImportTrigger,
     X: TrackCleanup,
 {
     pub async fn run(&self) -> Result<()> {
@@ -115,6 +124,7 @@ where
                 &self.cue_scanner,
                 &self.cue_input_inspector,
                 &self.cue_splitter,
+                &self.manual_import,
                 download.clone(),
             )
             .await
@@ -150,11 +160,12 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::MonitorService;
+    use super::{MonitorService, ProcessingAdapters};
     use crate::adapters::sqlite_download_store::SqliteDownloadStore;
     use crate::application::ports::{
         CueInputInspector, CueInputSnapshot, CueReferencedAudioInput, CueScanner, CueSplitter,
-        DownloadStore, QueueSource, TrackCleanup,
+        DownloadStore, ManualImportRequest, ManualImportResult, ManualImportTrigger, QueueSource,
+        TrackCleanup,
     };
     use crate::domain::{
         DiscoveredCueSheets, DownloadLifecycleState, FailedImportCandidate, QueueSnapshot,
@@ -254,6 +265,17 @@ mod tests {
         }
     }
 
+    struct FakeManualImport;
+
+    impl ManualImportTrigger for FakeManualImport {
+        async fn trigger_manual_import(
+            &self,
+            _request: ManualImportRequest,
+        ) -> anyhow::Result<ManualImportResult> {
+            Ok(ManualImportResult::Disabled)
+        }
+    }
+
     #[tokio::test]
     async fn run_once_processes_then_completes_without_deleting_history() {
         let tmp = tempdir().unwrap();
@@ -301,14 +323,17 @@ FILE "album.flac" WAVE
         let service = MonitorService::new(
             queue,
             store.clone(),
-            FakeScanner {
-                cue_path: cue_path.clone(),
+            ProcessingAdapters {
+                cue_scanner: FakeScanner {
+                    cue_path: cue_path.clone(),
+                },
+                cue_input_inspector: FakeInspector,
+                cue_splitter: FakeSplitter {
+                    output_track: split_track.clone(),
+                },
+                manual_import: FakeManualImport,
+                track_cleanup: FakeCleanup,
             },
-            FakeInspector,
-            FakeSplitter {
-                output_track: split_track.clone(),
-            },
-            FakeCleanup,
             60,
         );
 

--- a/src/application/service.rs
+++ b/src/application/service.rs
@@ -6,37 +6,39 @@ use chrono::prelude::*;
 use crate::application::cleanup_processed_download::cleanup_processed_download;
 use crate::application::monitor_download_queue::classify_downloads;
 use crate::application::ports::{
-    CueInputInspector, CueScanner, CueSplitter, DownloadStore, ManualImportTrigger, QueueSource,
-    TrackCleanup,
+    CueInputInspector, CueScanner, CueSplitter, DownloadLog, DownloadStore, ManualImportTrigger,
+    QueueSource, TrackCleanup,
 };
 use crate::application::process_tracked_download::{
     process_tracked_download, register_failed_imports,
 };
 
-pub struct MonitorService<Q, S, C, I, P, M, X> {
+pub struct MonitorService<Q, S, C, I, P, M, L, X> {
     queue_source: Q,
     download_store: S,
     cue_scanner: C,
     cue_input_inspector: I,
     cue_splitter: P,
     manual_import: M,
+    download_log: L,
     track_cleanup: X,
     check_frequency_seconds: u64,
 }
 
-pub struct ProcessingAdapters<C, I, P, M, X> {
+pub struct ProcessingAdapters<C, I, P, M, L, X> {
     pub cue_scanner: C,
     pub cue_input_inspector: I,
     pub cue_splitter: P,
     pub manual_import: M,
+    pub download_log: L,
     pub track_cleanup: X,
 }
 
-impl<Q, S, C, I, P, M, X> MonitorService<Q, S, C, I, P, M, X> {
+impl<Q, S, C, I, P, M, L, X> MonitorService<Q, S, C, I, P, M, L, X> {
     pub fn new(
         queue_source: Q,
         download_store: S,
-        adapters: ProcessingAdapters<C, I, P, M, X>,
+        adapters: ProcessingAdapters<C, I, P, M, L, X>,
         check_frequency_seconds: u64,
     ) -> Self {
         Self {
@@ -46,13 +48,14 @@ impl<Q, S, C, I, P, M, X> MonitorService<Q, S, C, I, P, M, X> {
             cue_input_inspector: adapters.cue_input_inspector,
             cue_splitter: adapters.cue_splitter,
             manual_import: adapters.manual_import,
+            download_log: adapters.download_log,
             track_cleanup: adapters.track_cleanup,
             check_frequency_seconds,
         }
     }
 }
 
-impl<Q, S, C, I, P, M, X> MonitorService<Q, S, C, I, P, M, X>
+impl<Q, S, C, I, P, M, L, X> MonitorService<Q, S, C, I, P, M, L, X>
 where
     Q: QueueSource,
     S: DownloadStore,
@@ -60,6 +63,7 @@ where
     I: CueInputInspector,
     P: CueSplitter,
     M: ManualImportTrigger,
+    L: DownloadLog,
     X: TrackCleanup,
 {
     pub async fn run(&self) -> Result<()> {
@@ -125,6 +129,7 @@ where
                 &self.cue_input_inspector,
                 &self.cue_splitter,
                 &self.manual_import,
+                &self.download_log,
                 download.clone(),
             )
             .await
@@ -139,9 +144,13 @@ where
 
         for download in to_cleanup {
             println!("Cleaning up {}", download.title);
-            if let Err(err) =
-                cleanup_processed_download(&self.download_store, &self.track_cleanup, &download)
-                    .await
+            if let Err(err) = cleanup_processed_download(
+                &self.download_store,
+                &self.track_cleanup,
+                &self.download_log,
+                &download,
+            )
+            .await
             {
                 eprintln!("Failed cleaning up {}: {err:#}", download.title);
             }
@@ -164,8 +173,8 @@ mod tests {
     use crate::adapters::sqlite_download_store::SqliteDownloadStore;
     use crate::application::ports::{
         CueInputInspector, CueInputSnapshot, CueReferencedAudioInput, CueScanner, CueSplitter,
-        DownloadStore, ManualImportRequest, ManualImportResult, ManualImportTrigger, QueueSource,
-        TrackCleanup,
+        DownloadLog, DownloadStore, ManualImportRequest, ManualImportResult, ManualImportTrigger,
+        QueueSource, TrackCleanup,
     };
     use crate::domain::{
         DiscoveredCueSheets, DownloadLifecycleState, FailedImportCandidate, QueueSnapshot,
@@ -276,6 +285,25 @@ mod tests {
         }
     }
 
+    struct FakeDownloadLog;
+
+    impl DownloadLog for FakeDownloadLog {
+        async fn write_download_log(
+            &self,
+            _download: &crate::domain::TrackedDownload,
+            _content: &str,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn delete_download_log(
+            &self,
+            _download: &crate::domain::TrackedDownload,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
     #[tokio::test]
     async fn run_once_processes_then_completes_without_deleting_history() {
         let tmp = tempdir().unwrap();
@@ -332,6 +360,7 @@ FILE "album.flac" WAVE
                     output_track: split_track.clone(),
                 },
                 manual_import: FakeManualImport,
+                download_log: FakeDownloadLog,
                 track_cleanup: FakeCleanup,
             },
             60,

--- a/src/bootstrap/settings.rs
+++ b/src/bootstrap/settings.rs
@@ -40,10 +40,33 @@ pub struct ServerSettings {
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct LoggingSettings {
+    pub download_log_enabled: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct GnudbSettings {
+    pub disc_lookup_enabled: bool,
+    pub server: String,
+    pub user_email: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct MusicBrainzSettings {
+    pub disc_lookup_enabled: bool,
+    pub base_url: String,
+    pub trust_disc_lookup: bool,
+    pub add_missing_release_group_enabled: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct Settings {
     pub data_dir: PathBuf,
     pub check_frequency_seconds: u64,
     pub server: ServerSettings,
+    pub logging: LoggingSettings,
+    pub gnudb: GnudbSettings,
+    pub musicbrainz: MusicBrainzSettings,
     pub cue: CueSettings,
     pub lidarr: LidarrSettings,
     pub shnsplit: ShnsplitSettings,
@@ -55,6 +78,12 @@ pub enum SettingsError {
     MissingProjectDirs,
     #[error(transparent)]
     Config(#[from] ConfigError),
+    #[error("gnudb.user_email is required when gnudb.disc_lookup_enabled is true")]
+    MissingGnudbUserEmail,
+    #[error("gnudb.server must be a hostname or unique code, not a URL or path: {0}")]
+    InvalidGnudbServer(String),
+    #[error("musicbrainz.base_url must be an HTTP(S) base URL: {0}")]
+    InvalidMusicBrainzBaseUrl(String),
 }
 
 impl Settings {
@@ -77,10 +106,18 @@ impl Settings {
             .set_default("data_dir", default_data_dir.to_string_lossy().to_string())?
             .set_default("check_frequency_seconds", 60)?
             .set_default("server.bind_address", "127.0.0.1:9899")?
+            .set_default("logging.download_log_enabled", true)?
+            .set_default("gnudb.disc_lookup_enabled", false)?
+            .set_default("gnudb.server", "gnudb.gnudb.org")?
+            .set_default("gnudb.user_email", "")?
+            .set_default("musicbrainz.disc_lookup_enabled", true)?
+            .set_default("musicbrainz.base_url", "https://musicbrainz.org")?
+            .set_default("musicbrainz.trust_disc_lookup", false)?
+            .set_default("musicbrainz.add_missing_release_group_enabled", false)?
             .set_default("cue.strict", false)?
             .set_default("lidarr.queue_page_size", 100)?
             .set_default("lidarr.queue_max_pages", 100)?
-            .set_default("lidarr.manual_import_enabled", false)?
+            .set_default("lidarr.manual_import_enabled", true)?
             .set_default("shnsplit.path", "shnsplit")?
             .set_default("shnsplit.overwrite", true)?
             .set_default("shnsplit.format", "%p - %a - %n - %t")?
@@ -104,8 +141,53 @@ impl Settings {
             )
             .build()?;
 
-        Ok(config.try_deserialize::<Settings>()?)
+        let mut settings = config.try_deserialize::<Settings>()?;
+        settings.gnudb.server = normalize_gnudb_server(&settings.gnudb.server)?;
+        settings.musicbrainz.base_url =
+            normalize_musicbrainz_base_url(&settings.musicbrainz.base_url)?;
+        if settings.gnudb.disc_lookup_enabled && !looks_like_email(&settings.gnudb.user_email) {
+            return Err(SettingsError::MissingGnudbUserEmail);
+        }
+
+        Ok(settings)
     }
+}
+
+fn normalize_musicbrainz_base_url(value: &str) -> Result<String, SettingsError> {
+    let value = value.trim().trim_end_matches('/');
+    if value.starts_with("http://") || value.starts_with("https://") {
+        Ok(value.to_owned())
+    } else {
+        Err(SettingsError::InvalidMusicBrainzBaseUrl(value.to_owned()))
+    }
+}
+
+fn normalize_gnudb_server(value: &str) -> Result<String, SettingsError> {
+    let value = value.trim().trim_end_matches('.');
+    if value.is_empty()
+        || value.contains("://")
+        || value.contains('/')
+        || value.contains('?')
+        || value.contains('#')
+    {
+        return Err(SettingsError::InvalidGnudbServer(value.to_owned()));
+    }
+
+    if value.eq_ignore_ascii_case("gnudb.gnudb.org")
+        || value.to_ascii_lowercase().ends_with(".gnudb.org")
+    {
+        Ok(value.to_ascii_lowercase())
+    } else {
+        Ok(format!("{}.gnudb.org", value.to_ascii_lowercase()))
+    }
+}
+
+fn looks_like_email(value: &str) -> bool {
+    let value = value.trim();
+    let Some((name, domain)) = value.split_once('@') else {
+        return false;
+    };
+    !name.is_empty() && domain.contains('.') && !domain.ends_with('.')
 }
 
 #[cfg(test)]
@@ -118,6 +200,28 @@ mod tests {
     use super::*;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn download_log_is_enabled_by_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_test_env();
+        let tmp = tempdir().unwrap();
+        let config_path = tmp.path().join("splittarr.toml");
+        fs::write(
+            &config_path,
+            r#"
+[lidarr]
+url = "http://lidarr"
+api_key = "secret"
+"#,
+        )
+        .unwrap();
+
+        let settings =
+            Settings::load_with_paths(Some(config_path), tmp.path().join("default"), None).unwrap();
+
+        assert!(settings.logging.download_log_enabled);
+    }
 
     #[test]
     fn explicit_config_overrides_defaults() {
@@ -141,6 +245,20 @@ manual_import_enabled = true
 [server]
 bind_address = "127.0.0.1:9899"
 
+[logging]
+download_log_enabled = false
+
+[gnudb]
+disc_lookup_enabled = true
+server = "4ckgj7jx"
+user_email = "user@example.com"
+
+[musicbrainz]
+disc_lookup_enabled = true
+base_url = "https://musicbrainz.example/"
+trust_disc_lookup = true
+add_missing_release_group_enabled = true
+
 [cue]
 strict = true
 
@@ -158,6 +276,14 @@ format = "%n - %t"
         assert_eq!(settings.check_frequency_seconds, 5);
         assert_eq!(settings.data_dir, PathBuf::from("/tmp/splittarr-data"));
         assert_eq!(settings.server.bind_address, "127.0.0.1:9899");
+        assert!(!settings.logging.download_log_enabled);
+        assert!(settings.gnudb.disc_lookup_enabled);
+        assert_eq!(settings.gnudb.server, "4ckgj7jx.gnudb.org");
+        assert_eq!(settings.gnudb.user_email, "user@example.com");
+        assert!(settings.musicbrainz.disc_lookup_enabled);
+        assert_eq!(settings.musicbrainz.base_url, "https://musicbrainz.example");
+        assert!(settings.musicbrainz.trust_disc_lookup);
+        assert!(settings.musicbrainz.add_missing_release_group_enabled);
         assert!(settings.cue.strict);
         assert_eq!(settings.lidarr.url, "http://lidarr");
         assert_eq!(settings.lidarr.queue_page_size, 25);
@@ -188,6 +314,17 @@ api_key = "file-secret"
         std::env::set_var("SPLITTARR_CHECK_FREQUENCY_SECONDS", "9");
         std::env::set_var("SPLITTARR_LIDARR__URL", "http://from-env");
         std::env::set_var("SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED", "true");
+        std::env::set_var("SPLITTARR_LOGGING__DOWNLOAD_LOG_ENABLED", "false");
+        std::env::set_var("SPLITTARR_GNUDB__DISC_LOOKUP_ENABLED", "true");
+        std::env::set_var("SPLITTARR_GNUDB__SERVER", "abcd1234.gnudb.org");
+        std::env::set_var("SPLITTARR_GNUDB__USER_EMAIL", "env@example.com");
+        std::env::set_var("SPLITTARR_MUSICBRAINZ__DISC_LOOKUP_ENABLED", "true");
+        std::env::set_var("SPLITTARR_MUSICBRAINZ__BASE_URL", "http://mb-env/");
+        std::env::set_var("SPLITTARR_MUSICBRAINZ__TRUST_DISC_LOOKUP", "true");
+        std::env::set_var(
+            "SPLITTARR_MUSICBRAINZ__ADD_MISSING_RELEASE_GROUP_ENABLED",
+            "true",
+        );
         std::env::set_var("SPLITTARR_SERVER__BIND_ADDRESS", "0.0.0.0:1234");
 
         let settings =
@@ -196,19 +333,125 @@ api_key = "file-secret"
         std::env::remove_var("SPLITTARR_CHECK_FREQUENCY_SECONDS");
         std::env::remove_var("SPLITTARR_LIDARR__URL");
         std::env::remove_var("SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED");
+        std::env::remove_var("SPLITTARR_LOGGING__DOWNLOAD_LOG_ENABLED");
+        std::env::remove_var("SPLITTARR_GNUDB__DISC_LOOKUP_ENABLED");
+        std::env::remove_var("SPLITTARR_GNUDB__SERVER");
+        std::env::remove_var("SPLITTARR_GNUDB__USER_EMAIL");
+        std::env::remove_var("SPLITTARR_MUSICBRAINZ__DISC_LOOKUP_ENABLED");
+        std::env::remove_var("SPLITTARR_MUSICBRAINZ__BASE_URL");
+        std::env::remove_var("SPLITTARR_MUSICBRAINZ__TRUST_DISC_LOOKUP");
+        std::env::remove_var("SPLITTARR_MUSICBRAINZ__ADD_MISSING_RELEASE_GROUP_ENABLED");
         std::env::remove_var("SPLITTARR_SERVER__BIND_ADDRESS");
 
         assert_eq!(settings.check_frequency_seconds, 9);
         assert_eq!(settings.lidarr.url, "http://from-env");
         assert_eq!(settings.lidarr.api_key, "file-secret");
         assert!(settings.lidarr.manual_import_enabled);
+        assert!(!settings.logging.download_log_enabled);
+        assert!(settings.gnudb.disc_lookup_enabled);
+        assert_eq!(settings.gnudb.server, "abcd1234.gnudb.org");
+        assert_eq!(settings.gnudb.user_email, "env@example.com");
+        assert!(settings.musicbrainz.disc_lookup_enabled);
+        assert_eq!(settings.musicbrainz.base_url, "http://mb-env");
+        assert!(settings.musicbrainz.trust_disc_lookup);
+        assert!(settings.musicbrainz.add_missing_release_group_enabled);
         assert_eq!(settings.server.bind_address, "0.0.0.0:1234");
+    }
+
+    #[test]
+    fn gnudb_lookup_is_disabled_by_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_test_env();
+        let tmp = tempdir().unwrap();
+        let config_path = tmp.path().join("splittarr.toml");
+        fs::write(
+            &config_path,
+            r#"
+[lidarr]
+url = "http://lidarr"
+api_key = "secret"
+"#,
+        )
+        .unwrap();
+
+        let settings =
+            Settings::load_with_paths(Some(config_path), tmp.path().join("default"), None).unwrap();
+
+        assert!(!settings.gnudb.disc_lookup_enabled);
+        assert_eq!(settings.gnudb.server, "gnudb.gnudb.org");
+        assert_eq!(settings.gnudb.user_email, "");
+        assert!(settings.musicbrainz.disc_lookup_enabled);
+        assert_eq!(settings.musicbrainz.base_url, "https://musicbrainz.org");
+        assert!(!settings.musicbrainz.trust_disc_lookup);
+        assert!(!settings.musicbrainz.add_missing_release_group_enabled);
+        assert!(settings.lidarr.manual_import_enabled);
+    }
+
+    #[test]
+    fn gnudb_server_normalizes_bare_code_and_hostname() {
+        assert_eq!(
+            normalize_gnudb_server("4ckgj7jx").unwrap(),
+            "4ckgj7jx.gnudb.org"
+        );
+        assert_eq!(
+            normalize_gnudb_server("4ckgj7jx.gnudb.org").unwrap(),
+            "4ckgj7jx.gnudb.org"
+        );
+        assert_eq!(
+            normalize_gnudb_server("GNUDB.GNUDB.ORG").unwrap(),
+            "gnudb.gnudb.org"
+        );
+    }
+
+    #[test]
+    fn gnudb_server_rejects_url_or_path_values() {
+        assert!(matches!(
+            normalize_gnudb_server("https://gnudb.gnudb.org/~cddb/cddb.cgi"),
+            Err(SettingsError::InvalidGnudbServer(_))
+        ));
+        assert!(matches!(
+            normalize_gnudb_server("gnudb.gnudb.org/~cddb/cddb.cgi"),
+            Err(SettingsError::InvalidGnudbServer(_))
+        ));
+    }
+
+    #[test]
+    fn gnudb_lookup_requires_user_email_when_enabled() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear_test_env();
+        let tmp = tempdir().unwrap();
+        let config_path = tmp.path().join("splittarr.toml");
+        fs::write(
+            &config_path,
+            r#"
+[lidarr]
+url = "http://lidarr"
+api_key = "secret"
+
+[gnudb]
+disc_lookup_enabled = true
+"#,
+        )
+        .unwrap();
+
+        let err = Settings::load_with_paths(Some(config_path), tmp.path().join("default"), None)
+            .unwrap_err();
+
+        assert!(matches!(err, SettingsError::MissingGnudbUserEmail));
     }
 
     fn clear_test_env() {
         std::env::remove_var("SPLITTARR_CHECK_FREQUENCY_SECONDS");
         std::env::remove_var("SPLITTARR_LIDARR__URL");
         std::env::remove_var("SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED");
+        std::env::remove_var("SPLITTARR_LOGGING__DOWNLOAD_LOG_ENABLED");
+        std::env::remove_var("SPLITTARR_GNUDB__DISC_LOOKUP_ENABLED");
+        std::env::remove_var("SPLITTARR_GNUDB__SERVER");
+        std::env::remove_var("SPLITTARR_GNUDB__USER_EMAIL");
+        std::env::remove_var("SPLITTARR_MUSICBRAINZ__DISC_LOOKUP_ENABLED");
+        std::env::remove_var("SPLITTARR_MUSICBRAINZ__BASE_URL");
+        std::env::remove_var("SPLITTARR_MUSICBRAINZ__TRUST_DISC_LOOKUP");
+        std::env::remove_var("SPLITTARR_MUSICBRAINZ__ADD_MISSING_RELEASE_GROUP_ENABLED");
         std::env::remove_var("SPLITTARR_SERVER__BIND_ADDRESS");
     }
 }

--- a/src/bootstrap/settings.rs
+++ b/src/bootstrap/settings.rs
@@ -78,7 +78,7 @@ pub enum SettingsError {
     MissingProjectDirs,
     #[error(transparent)]
     Config(#[from] ConfigError),
-    #[error("gnudb.user_email is required when gnudb.disc_lookup_enabled is true")]
+    #[error("gnudb.user_email must be a valid email when gnudb.disc_lookup_enabled is true")]
     MissingGnudbUserEmail,
     #[error("gnudb.server must be a hostname or unique code, not a URL or path: {0}")]
     InvalidGnudbServer(String),
@@ -155,11 +155,18 @@ impl Settings {
 
 fn normalize_musicbrainz_base_url(value: &str) -> Result<String, SettingsError> {
     let value = value.trim().trim_end_matches('/');
-    if value.starts_with("http://") || value.starts_with("https://") {
-        Ok(value.to_owned())
-    } else {
-        Err(SettingsError::InvalidMusicBrainzBaseUrl(value.to_owned()))
+    if !value.starts_with("http://") && !value.starts_with("https://") {
+        return Err(SettingsError::InvalidMusicBrainzBaseUrl(value.to_owned()));
     }
+
+    let Some(origin) = value.split("://").nth(1) else {
+        return Err(SettingsError::InvalidMusicBrainzBaseUrl(value.to_owned()));
+    };
+    if origin.is_empty() || origin.contains('/') || origin.contains('?') || origin.contains('#') {
+        return Err(SettingsError::InvalidMusicBrainzBaseUrl(value.to_owned()));
+    }
+
+    Ok(value.to_owned())
 }
 
 fn normalize_gnudb_server(value: &str) -> Result<String, SettingsError> {
@@ -413,6 +420,32 @@ api_key = "secret"
             normalize_gnudb_server("gnudb.gnudb.org/~cddb/cddb.cgi"),
             Err(SettingsError::InvalidGnudbServer(_))
         ));
+    }
+
+    #[test]
+    fn musicbrainz_base_url_normalizes_origin() {
+        assert_eq!(
+            normalize_musicbrainz_base_url("https://musicbrainz.org/").unwrap(),
+            "https://musicbrainz.org"
+        );
+        assert_eq!(
+            normalize_musicbrainz_base_url("http://musicbrainz.example").unwrap(),
+            "http://musicbrainz.example"
+        );
+    }
+
+    #[test]
+    fn musicbrainz_base_url_rejects_path_query_or_fragment() {
+        for value in [
+            "https://musicbrainz.org/ws/2",
+            "https://musicbrainz.org?x=y",
+            "https://musicbrainz.org#fragment",
+        ] {
+            assert!(matches!(
+                normalize_musicbrainz_base_url(value),
+                Err(SettingsError::InvalidMusicBrainzBaseUrl(_))
+            ));
+        }
     }
 
     #[test]

--- a/src/bootstrap/settings.rs
+++ b/src/bootstrap/settings.rs
@@ -24,6 +24,7 @@ pub struct LidarrSettings {
     pub api_key: String,
     pub queue_page_size: usize,
     pub queue_max_pages: usize,
+    pub manual_import_enabled: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -79,6 +80,7 @@ impl Settings {
             .set_default("cue.strict", false)?
             .set_default("lidarr.queue_page_size", 100)?
             .set_default("lidarr.queue_max_pages", 100)?
+            .set_default("lidarr.manual_import_enabled", false)?
             .set_default("shnsplit.path", "shnsplit")?
             .set_default("shnsplit.overwrite", true)?
             .set_default("shnsplit.format", "%p - %a - %n - %t")?
@@ -134,6 +136,7 @@ url = "http://lidarr"
 api_key = "secret"
 queue_page_size = 25
 queue_max_pages = 20
+manual_import_enabled = true
 
 [server]
 bind_address = "127.0.0.1:9899"
@@ -159,6 +162,7 @@ format = "%n - %t"
         assert_eq!(settings.lidarr.url, "http://lidarr");
         assert_eq!(settings.lidarr.queue_page_size, 25);
         assert_eq!(settings.lidarr.queue_max_pages, 20);
+        assert!(settings.lidarr.manual_import_enabled);
         assert_eq!(settings.shnsplit.path, PathBuf::from("/usr/bin/shnsplit"));
         assert!(!settings.shnsplit.overwrite);
     }
@@ -183,6 +187,7 @@ api_key = "file-secret"
 
         std::env::set_var("SPLITTARR_CHECK_FREQUENCY_SECONDS", "9");
         std::env::set_var("SPLITTARR_LIDARR__URL", "http://from-env");
+        std::env::set_var("SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED", "true");
         std::env::set_var("SPLITTARR_SERVER__BIND_ADDRESS", "0.0.0.0:1234");
 
         let settings =
@@ -190,17 +195,20 @@ api_key = "file-secret"
 
         std::env::remove_var("SPLITTARR_CHECK_FREQUENCY_SECONDS");
         std::env::remove_var("SPLITTARR_LIDARR__URL");
+        std::env::remove_var("SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED");
         std::env::remove_var("SPLITTARR_SERVER__BIND_ADDRESS");
 
         assert_eq!(settings.check_frequency_seconds, 9);
         assert_eq!(settings.lidarr.url, "http://from-env");
         assert_eq!(settings.lidarr.api_key, "file-secret");
+        assert!(settings.lidarr.manual_import_enabled);
         assert_eq!(settings.server.bind_address, "0.0.0.0:1234");
     }
 
     fn clear_test_env() {
         std::env::remove_var("SPLITTARR_CHECK_FREQUENCY_SECONDS");
         std::env::remove_var("SPLITTARR_LIDARR__URL");
+        std::env::remove_var("SPLITTARR_LIDARR__MANUAL_IMPORT_ENABLED");
         std::env::remove_var("SPLITTARR_SERVER__BIND_ADDRESS");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,18 @@ mod application;
 mod bootstrap;
 mod domain;
 
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
 use clap::Parser;
 
 use crate::adapters::filesystem_cleanup::FilesystemTrackCleanup;
 use crate::adapters::filesystem_cue_input_inspector::FilesystemCueInputInspector;
 use crate::adapters::filesystem_cue_scanner::FilesystemCueScanner;
+use crate::adapters::filesystem_download_log::FilesystemDownloadLog;
+use crate::adapters::gnudb_api::GnudbDiscReleaseLookup;
 use crate::adapters::lidarr_api::LidarrQueueSource;
+use crate::adapters::musicbrainz_api::FilesystemMusicBrainzDiscReleaseLookup;
 use crate::adapters::shnsplit_splitter::ShnsplitCueSplitter;
 use crate::adapters::sqlite_download_store::SqliteDownloadStore;
 use crate::adapters::web;
@@ -20,13 +25,24 @@ use crate::bootstrap::settings::{Cli, Settings};
 async fn main() -> Result<()> {
     let cli = Cli::parse();
     let settings = Settings::load(cli.config).context("load settings")?;
-    let queue_source = LidarrQueueSource::new(&settings.lidarr);
+    let disc_release_lookup = Arc::new(GnudbDiscReleaseLookup::new(&settings.gnudb));
+    let musicbrainz_lookup = Arc::new(FilesystemMusicBrainzDiscReleaseLookup::new(
+        &settings.musicbrainz,
+    ));
+    let queue_source = LidarrQueueSource::new(&settings.lidarr)
+        .with_musicbrainz_disc_release_lookup(musicbrainz_lookup)
+        .with_musicbrainz_trust_disc_lookup(settings.musicbrainz.trust_disc_lookup)
+        .with_musicbrainz_add_missing_release_group(
+            settings.musicbrainz.add_missing_release_group_enabled,
+        )
+        .with_disc_release_lookup(disc_release_lookup);
     let manual_import = queue_source.clone();
     let download_store =
         SqliteDownloadStore::open(&settings.data_dir).context("initialize Splittarr database")?;
     let web_store = download_store.clone();
     let cue_scanner = FilesystemCueScanner::new();
     let cue_input_inspector = FilesystemCueInputInspector::new();
+    let download_log = FilesystemDownloadLog::new(settings.logging.download_log_enabled);
     let cue_splitter = ShnsplitCueSplitter::new(
         settings.cue.strict,
         settings.shnsplit.path.clone(),
@@ -42,6 +58,7 @@ async fn main() -> Result<()> {
             cue_input_inspector,
             cue_splitter,
             manual_import,
+            download_log,
             track_cleanup,
         },
         settings.check_frequency_seconds,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use crate::adapters::lidarr_api::LidarrQueueSource;
 use crate::adapters::shnsplit_splitter::ShnsplitCueSplitter;
 use crate::adapters::sqlite_download_store::SqliteDownloadStore;
 use crate::adapters::web;
-use crate::application::service::MonitorService;
+use crate::application::service::{MonitorService, ProcessingAdapters};
 use crate::bootstrap::settings::{Cli, Settings};
 
 #[tokio::main]
@@ -21,6 +21,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let settings = Settings::load(cli.config).context("load settings")?;
     let queue_source = LidarrQueueSource::new(&settings.lidarr);
+    let manual_import = queue_source.clone();
     let download_store =
         SqliteDownloadStore::open(&settings.data_dir).context("initialize Splittarr database")?;
     let web_store = download_store.clone();
@@ -36,10 +37,13 @@ async fn main() -> Result<()> {
     let service = MonitorService::new(
         queue_source,
         download_store,
-        cue_scanner,
-        cue_input_inspector,
-        cue_splitter,
-        track_cleanup,
+        ProcessingAdapters {
+            cue_scanner,
+            cue_input_inspector,
+            cue_splitter,
+            manual_import,
+            track_cleanup,
+        },
         settings.check_frequency_seconds,
     );
     let listener = tokio::net::TcpListener::bind(&settings.server.bind_address)


### PR DESCRIPTION
## Summary
- add optional Lidarr manual import triggering after successful splitting
- validate manual import candidates against generated tracks and cue metadata hints
- expose the new setting in config and README

## Validation
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings (fails: cloned_ref_to_slice_refs in src/application/process_tracked_download.rs:707)
- cargo test