### PR TITLE
feat(web): add status page

### DIFF
--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -179,8 +179,9 @@ impl SqliteDownloadStore {
 
     fn load_download_stats_sync(&self) -> Result<DownloadStats> {
         let conn = self.connect()?;
-        let mut stmt = conn
-            .prepare("SELECT lifecycle_state, COUNT(*) FROM downloads GROUP BY lifecycle_state")?;
+        let mut stmt = conn.prepare(
+            "SELECT COALESCE(lifecycle_state, 'detected'), COUNT(*) FROM downloads GROUP BY lifecycle_state",
+        )?;
         let rows = stmt.query_map([], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
         })?;

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -182,18 +182,20 @@ impl SqliteDownloadStore {
         let mut stmt = conn
             .prepare("SELECT lifecycle_state, COUNT(*) FROM downloads GROUP BY lifecycle_state")?;
         let rows = stmt.query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, usize>(1)?))
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
         })?;
         let mut stats = DownloadStats::default();
         for row in rows {
             let (state, count) = row?;
+            let count = count as usize;
             stats.total += count;
-            match state.as_str() {
-                "completed" => stats.completed += count,
-                "failed" => stats.failed += count,
-                "awaiting_import" => stats.awaiting_import += count,
-                "detected" | "processing" | "cleaning_up" => stats.in_progress += count,
-                _ => {}
+            match download_lifecycle_state_from_db(&state) {
+                DownloadLifecycleState::Completed => stats.completed += count,
+                DownloadLifecycleState::Failed => stats.failed += count,
+                DownloadLifecycleState::AwaitingImport => stats.awaiting_import += count,
+                DownloadLifecycleState::Detected
+                | DownloadLifecycleState::Processing
+                | DownloadLifecycleState::CleaningUp => stats.in_progress += count,
             }
         }
         Ok(stats)

--- a/src/adapters/sqlite_download_store.rs
+++ b/src/adapters/sqlite_download_store.rs
@@ -7,7 +7,9 @@ use async_trait::async_trait;
 use rusqlite::{named_params, params, params_from_iter, Connection, OptionalExtension};
 use uuid::Uuid;
 
-use crate::application::ports::{DownloadHistoryRow, DownloadReadStore, DownloadStore};
+use crate::application::ports::{
+    DownloadHistoryRow, DownloadReadStore, DownloadStats, DownloadStore,
+};
 use crate::domain::{
     CueSheet, CueSheetStatus, DownloadLifecycleState, GeneratedTrack, InputFile, InputFileKind,
     RecordedTrack, TrackCleanupOutcome, TrackCleanupStatus, TrackedDownload,
@@ -173,6 +175,28 @@ impl SqliteDownloadStore {
             }
         }
         Ok(downloads)
+    }
+
+    fn load_download_stats_sync(&self) -> Result<DownloadStats> {
+        let conn = self.connect()?;
+        let mut stmt = conn
+            .prepare("SELECT lifecycle_state, COUNT(*) FROM downloads GROUP BY lifecycle_state")?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, usize>(1)?))
+        })?;
+        let mut stats = DownloadStats::default();
+        for row in rows {
+            let (state, count) = row?;
+            stats.total += count;
+            match state.as_str() {
+                "completed" => stats.completed += count,
+                "failed" => stats.failed += count,
+                "awaiting_import" => stats.awaiting_import += count,
+                "detected" | "processing" | "cleaning_up" => stats.in_progress += count,
+                _ => {}
+            }
+        }
+        Ok(stats)
     }
 
     fn upsert_tracked_download_sync(&self, download: &TrackedDownload) -> Result<()> {
@@ -660,6 +684,13 @@ impl DownloadReadStore for SqliteDownloadStore {
         let store = self.clone();
         let download_id = download_id.to_owned();
         tokio::task::spawn_blocking(move || store.get_tracked_download_sync(&download_id))
+            .await
+            .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
+    }
+
+    async fn load_download_stats(&self) -> Result<DownloadStats> {
+        let store = self.clone();
+        tokio::task::spawn_blocking(move || store.load_download_stats_sync())
             .await
             .map_err(|err| anyhow!("blocking task failed to join: {err}"))?
     }

--- a/src/adapters/web.rs
+++ b/src/adapters/web.rs
@@ -7,23 +7,37 @@ use axum::{
 };
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 
-use crate::application::ports::{DownloadHistoryRow, DownloadReadStore};
+use crate::application::ports::{DownloadHistoryRow, DownloadReadStore, DownloadStats};
 use crate::domain::{
     CueSheet, CueSheetStatus, DownloadLifecycleState, GeneratedTrack, InputFile, InputFileKind,
     TrackCleanupStatus, TrackedDownload,
 };
 
 #[derive(Clone)]
-struct WebState<S> {
-    store: S,
+pub struct StatusConfig {
+    pub version: &'static str,
+    pub lidarr_url: String,
+    pub check_frequency_seconds: u64,
+    pub manual_import_enabled: bool,
+    pub musicbrainz_enabled: bool,
+    pub gnudb_enabled: bool,
+    pub cue_strict: bool,
+    pub download_log_enabled: bool,
 }
 
-pub fn router<S>(store: S) -> Router
+#[derive(Clone)]
+struct WebState<S> {
+    store: S,
+    status: StatusConfig,
+}
+
+pub fn router<S>(store: S, status: StatusConfig) -> Router
 where
     S: DownloadReadStore + Clone + Send + Sync + 'static,
 {
     Router::new()
         .route("/", get(index::<S>))
+        .route("/status", get(status_page::<S>))
         .route("/healthz", get(healthz))
         .route("/downloads/{download_id}", get(download_detail::<S>))
         .route(
@@ -32,11 +46,35 @@ where
         )
         .route("/downloads/{download_id}/row", get(download_row_route::<S>))
         .route("/downloads/rows", get(download_rows_route::<S>))
-        .with_state(WebState { store })
+        .with_state(WebState { store, status })
 }
 
 async fn healthz() -> impl IntoResponse {
     (StatusCode::OK, "ok")
+}
+
+async fn status_page<S>(State(state): State<WebState<S>>) -> Response
+where
+    S: DownloadReadStore,
+{
+    match state.store.load_download_stats().await {
+        Ok(stats) => Html(page(
+            "Splittarr — Status",
+            html! {
+                nav {
+                    a href="/" { "Download History" }
+                }
+                h1 { "Splittarr" }
+                (status_content(&state.status, &stats))
+            },
+        ))
+        .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to load status: {error}"),
+        )
+            .into_response(),
+    }
 }
 
 async fn index<S>(State(state): State<WebState<S>>) -> Response
@@ -47,6 +85,9 @@ where
         Ok(downloads) => Html(page(
             "Splittarr",
             html! {
+                nav {
+                    a href="/status" { "Status" }
+                }
                 h1 { "Splittarr" }
                 section class="panel" {
                     h2 { "Download History" }
@@ -178,6 +219,83 @@ fn page(title: &str, body: Markup) -> String {
         }
     }
     .into_string()
+}
+
+fn status_content(config: &StatusConfig, stats: &DownloadStats) -> Markup {
+    html! {
+        section class="panel grid" {
+            div {
+                strong { "Version" }
+                span { (config.version) }
+            }
+            div {
+                strong { "Lidarr URL" }
+                span class="path" { (&config.lidarr_url) }
+            }
+            div {
+                strong { "Check frequency" }
+                span { (config.check_frequency_seconds) " s" }
+            }
+        }
+        section class="panel" {
+            h2 { "Features" }
+            div class="grid" {
+                div {
+                    strong { "Manual import" }
+                    (feature_badge(config.manual_import_enabled))
+                }
+                div {
+                    strong { "MusicBrainz disc lookup" }
+                    (feature_badge(config.musicbrainz_enabled))
+                }
+                div {
+                    strong { "GnuDB disc lookup" }
+                    (feature_badge(config.gnudb_enabled))
+                }
+                div {
+                    strong { "Strict CUE mode" }
+                    (feature_badge(config.cue_strict))
+                }
+                div {
+                    strong { "Download logging" }
+                    (feature_badge(config.download_log_enabled))
+                }
+            }
+        }
+        section class="panel" {
+            h2 { "Downloads" }
+            div class="grid" {
+                div {
+                    strong { "Total" }
+                    span { (stats.total) }
+                }
+                div {
+                    strong { "Completed" }
+                    span class="status status-ok" { (stats.completed) }
+                }
+                div {
+                    strong { "Failed" }
+                    span class=(if stats.failed > 0 { "status status-error" } else { "status status-ok" }) { (stats.failed) }
+                }
+                div {
+                    strong { "Awaiting import" }
+                    span class=(if stats.awaiting_import > 0 { "status status-warn" } else { "status" }) { (stats.awaiting_import) }
+                }
+                div {
+                    strong { "In progress" }
+                    span class=(if stats.in_progress > 0 { "status status-active" } else { "status" }) { (stats.in_progress) }
+                }
+            }
+        }
+    }
+}
+
+fn feature_badge(enabled: bool) -> Markup {
+    if enabled {
+        html! { span class="status status-ok" { "enabled" } }
+    } else {
+        html! { span class="status" { "disabled" } }
+    }
 }
 
 fn download_row(download: &DownloadHistoryRow) -> Markup {
@@ -560,8 +678,8 @@ mod tests {
     use axum::http::Request;
     use tower::ServiceExt;
 
-    use super::router;
-    use crate::application::ports::{DownloadHistoryRow, DownloadReadStore};
+    use super::{router, StatusConfig};
+    use crate::application::ports::{DownloadHistoryRow, DownloadReadStore, DownloadStats};
     use crate::domain::{
         CueSheet, CueSheetStatus, DownloadLifecycleState, GeneratedTrack, InputFile, InputFileKind,
         TrackCleanupStatus, TrackedDownload,
@@ -600,11 +718,28 @@ mod tests {
                 .filter(|download| download.download_id == download_id)
                 .cloned())
         }
+
+        async fn load_download_stats(&self) -> anyhow::Result<DownloadStats> {
+            Ok(DownloadStats::default())
+        }
+    }
+
+    fn fake_status_config() -> StatusConfig {
+        StatusConfig {
+            version: "0.0.0-test",
+            lidarr_url: "http://lidarr:8686".into(),
+            check_frequency_seconds: 60,
+            manual_import_enabled: true,
+            musicbrainz_enabled: true,
+            gnudb_enabled: false,
+            cue_strict: false,
+            download_log_enabled: true,
+        }
     }
 
     #[tokio::test]
     async fn index_renders_empty_state_with_fake_read_store() {
-        let app = router(FakeReadStore::default());
+        let app = router(FakeReadStore::default(), fake_status_config());
 
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
@@ -654,10 +789,13 @@ mod tests {
             }],
         }];
 
-        let app = router(FakeReadStore {
-            detail: Some(download),
-            ..FakeReadStore::default()
-        });
+        let app = router(
+            FakeReadStore {
+                detail: Some(download),
+                ..FakeReadStore::default()
+            },
+            fake_status_config(),
+        );
         let response = app
             .oneshot(
                 Request::builder()
@@ -678,20 +816,23 @@ mod tests {
 
     #[tokio::test]
     async fn rows_endpoint_renders_all_rows_in_one_response() {
-        let app = router(FakeReadStore {
-            rows: vec![DownloadHistoryRow {
-                download_id: "abc".into(),
-                title: "Album".into(),
-                status: "completed".into(),
-                output_path: "/downloads/album".into(),
-                tracked_download_state: "importFailed".into(),
-                lifecycle_state: DownloadLifecycleState::Detected,
-                updated_at: "2026-06-12 12:00:00".into(),
-                completed_at: None,
-                generated_track_count: 0,
-            }],
-            detail: None,
-        });
+        let app = router(
+            FakeReadStore {
+                rows: vec![DownloadHistoryRow {
+                    download_id: "abc".into(),
+                    title: "Album".into(),
+                    status: "completed".into(),
+                    output_path: "/downloads/album".into(),
+                    tracked_download_state: "importFailed".into(),
+                    lifecycle_state: DownloadLifecycleState::Detected,
+                    updated_at: "2026-06-12 12:00:00".into(),
+                    completed_at: None,
+                    generated_track_count: 0,
+                }],
+                detail: None,
+            },
+            fake_status_config(),
+        );
         let response = app
             .oneshot(
                 Request::builder()

--- a/src/adapters/web.rs
+++ b/src/adapters/web.rs
@@ -77,11 +77,10 @@ where
             },
         ))
         .into_response(),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to load status: {error}"),
-        )
-            .into_response(),
+        Err(error) => {
+            eprintln!("failed to load status: {error:#}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+        }
     }
 }
 
@@ -125,11 +124,10 @@ where
             },
         ))
         .into_response(),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to load downloads: {error}"),
-        )
-            .into_response(),
+        Err(error) => {
+            eprintln!("failed to load downloads: {error:#}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+        }
     }
 }
 
@@ -143,11 +141,10 @@ where
     match state.store.load_download_row(&download_id).await {
         Ok(Some(download)) => download_row(&download).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "download not found").into_response(),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to load download row: {error}"),
-        )
-            .into_response(),
+        Err(error) => {
+            eprintln!("failed to load download row: {error:#}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+        }
     }
 }
 
@@ -157,11 +154,10 @@ where
 {
     match state.store.load_download_rows().await {
         Ok(downloads) => download_rows(&downloads).into_response(),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to load download rows: {error}"),
-        )
-            .into_response(),
+        Err(error) => {
+            eprintln!("failed to load download rows: {error:#}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+        }
     }
 }
 
@@ -185,11 +181,10 @@ where
         ))
         .into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "download not found").into_response(),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to load download detail: {error}"),
-        )
-            .into_response(),
+        Err(error) => {
+            eprintln!("failed to load download detail: {error:#}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+        }
     }
 }
 
@@ -203,11 +198,10 @@ where
     match state.store.get_tracked_download(&download_id).await {
         Ok(Some(download)) => download_content(&download).into_response(),
         Ok(None) => (StatusCode::NOT_FOUND, "download not found").into_response(),
-        Err(error) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to load download detail content: {error}"),
-        )
-            .into_response(),
+        Err(error) => {
+            eprintln!("failed to load download detail content: {error:#}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal server error").into_response()
+        }
     }
 }
 
@@ -916,5 +910,29 @@ mod tests {
         assert!(rendered.contains("download-row-abc"));
         assert!(rendered.contains("/downloads/abc"));
         assert!(rendered.contains("0"));
+    }
+
+    #[tokio::test]
+    async fn status_page_renders_config_and_stats() {
+        let app = router(FakeReadStore::default(), fake_status_config());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let rendered = String::from_utf8(body.to_vec()).unwrap();
+        assert!(rendered.contains("0.0.0-test"));
+        assert!(rendered.contains("http://lidarr:8686"));
+        assert!(rendered.contains("gnudb.gnudb.org"));
+        assert!(rendered.contains("%p - %a - %n - %t"));
+        assert!(rendered.contains("Download History"));
     }
 }

--- a/src/adapters/web.rs
+++ b/src/adapters/web.rs
@@ -16,13 +16,21 @@ use crate::domain::{
 #[derive(Clone)]
 pub struct StatusConfig {
     pub version: &'static str,
-    pub lidarr_url: String,
+    pub data_dir: String,
     pub check_frequency_seconds: u64,
+    pub download_log_enabled: bool,
+    pub lidarr_url: String,
     pub manual_import_enabled: bool,
     pub musicbrainz_enabled: bool,
+    pub musicbrainz_base_url: String,
+    pub musicbrainz_trust_disc_lookup: bool,
+    pub musicbrainz_add_missing_release_group: bool,
     pub gnudb_enabled: bool,
+    pub gnudb_server: String,
     pub cue_strict: bool,
-    pub download_log_enabled: bool,
+    pub shnsplit_path: String,
+    pub shnsplit_overwrite: bool,
+    pub shnsplit_format: String,
 }
 
 #[derive(Clone)]
@@ -223,42 +231,92 @@ fn page(title: &str, body: Markup) -> String {
 
 fn status_content(config: &StatusConfig, stats: &DownloadStats) -> Markup {
     html! {
-        section class="panel grid" {
-            div {
-                strong { "Version" }
-                span { (config.version) }
-            }
-            div {
-                strong { "Lidarr URL" }
-                span class="path" { (&config.lidarr_url) }
-            }
-            div {
-                strong { "Check frequency" }
-                span { (config.check_frequency_seconds) " s" }
+        section class="panel" {
+            h2 { "General" }
+            div class="grid" {
+                div {
+                    strong { "Version" }
+                    span { (config.version) }
+                }
+                div {
+                    strong { "Check frequency" }
+                    span { (config.check_frequency_seconds) " s" }
+                }
+                div {
+                    strong { "Download logging" }
+                    (feature_badge(config.download_log_enabled))
+                }
+                div class="wide" {
+                    strong { "Data directory" }
+                    span class="path" { (&config.data_dir) }
+                }
             }
         }
         section class="panel" {
-            h2 { "Features" }
+            h2 { "Lidarr" }
             div class="grid" {
                 div {
                     strong { "Manual import" }
                     (feature_badge(config.manual_import_enabled))
                 }
+                div class="wide" {
+                    strong { "URL" }
+                    span class="path" { (&config.lidarr_url) }
+                }
+            }
+        }
+        section class="panel" {
+            h2 { "MusicBrainz" }
+            div class="grid" {
                 div {
-                    strong { "MusicBrainz disc lookup" }
+                    strong { "Disc lookup" }
                     (feature_badge(config.musicbrainz_enabled))
                 }
                 div {
-                    strong { "GnuDB disc lookup" }
+                    strong { "Trust disc lookup" }
+                    (feature_badge(config.musicbrainz_trust_disc_lookup))
+                }
+                div {
+                    strong { "Add missing release group" }
+                    (feature_badge(config.musicbrainz_add_missing_release_group))
+                }
+                div class="wide" {
+                    strong { "Base URL" }
+                    span class="path" { (&config.musicbrainz_base_url) }
+                }
+            }
+        }
+        section class="panel" {
+            h2 { "GnuDB" }
+            div class="grid" {
+                div {
+                    strong { "Disc lookup" }
                     (feature_badge(config.gnudb_enabled))
+                }
+                div {
+                    strong { "Server" }
+                    span class=(if config.gnudb_enabled { "path" } else { "path muted" }) { (&config.gnudb_server) }
+                }
+            }
+        }
+        section class="panel" {
+            h2 { "shnsplit" }
+            div class="grid" {
+                div {
+                    strong { "Overwrite" }
+                    (feature_badge(config.shnsplit_overwrite))
                 }
                 div {
                     strong { "Strict CUE mode" }
                     (feature_badge(config.cue_strict))
                 }
                 div {
-                    strong { "Download logging" }
-                    (feature_badge(config.download_log_enabled))
+                    strong { "Output format" }
+                    code { (&config.shnsplit_format) }
+                }
+                div class="wide" {
+                    strong { "Path" }
+                    span class="path" { (&config.shnsplit_path) }
                 }
             }
         }
@@ -727,13 +785,21 @@ mod tests {
     fn fake_status_config() -> StatusConfig {
         StatusConfig {
             version: "0.0.0-test",
-            lidarr_url: "http://lidarr:8686".into(),
+            data_dir: "/config".into(),
             check_frequency_seconds: 60,
+            download_log_enabled: true,
+            lidarr_url: "http://lidarr:8686".into(),
             manual_import_enabled: true,
             musicbrainz_enabled: true,
+            musicbrainz_base_url: "https://musicbrainz.org".into(),
+            musicbrainz_trust_disc_lookup: false,
+            musicbrainz_add_missing_release_group: false,
             gnudb_enabled: false,
+            gnudb_server: "gnudb.gnudb.org".into(),
             cue_strict: false,
-            download_log_enabled: true,
+            shnsplit_path: "shnsplit".into(),
+            shnsplit_overwrite: true,
+            shnsplit_format: "%p - %a - %n - %t".into(),
         }
     }
 

--- a/src/application/ports.rs
+++ b/src/application/ports.rs
@@ -26,11 +26,21 @@ pub struct DownloadHistoryRow {
     pub generated_track_count: usize,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct DownloadStats {
+    pub total: usize,
+    pub completed: usize,
+    pub failed: usize,
+    pub awaiting_import: usize,
+    pub in_progress: usize,
+}
+
 #[async_trait]
 pub trait DownloadReadStore {
     async fn load_download_rows(&self) -> Result<Vec<DownloadHistoryRow>>;
     async fn load_download_row(&self, download_id: &str) -> Result<Option<DownloadHistoryRow>>;
     async fn get_tracked_download(&self, download_id: &str) -> Result<Option<TrackedDownload>>;
+    async fn load_download_stats(&self) -> Result<DownloadStats>;
 }
 
 pub trait DownloadStore {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,16 @@ async fn main() -> Result<()> {
     let download_store =
         SqliteDownloadStore::open(&settings.data_dir).context("initialize Splittarr database")?;
     let web_store = download_store.clone();
+    let status_config = web::StatusConfig {
+        version: env!("CARGO_PKG_VERSION"),
+        lidarr_url: settings.lidarr.url.clone(),
+        check_frequency_seconds: settings.check_frequency_seconds,
+        manual_import_enabled: settings.lidarr.manual_import_enabled,
+        musicbrainz_enabled: settings.musicbrainz.disc_lookup_enabled,
+        gnudb_enabled: settings.gnudb.disc_lookup_enabled,
+        cue_strict: settings.cue.strict,
+        download_log_enabled: settings.logging.download_log_enabled,
+    };
     let cue_scanner = FilesystemCueScanner::new();
     let cue_input_inspector = FilesystemCueInputInspector::new();
     let download_log = FilesystemDownloadLog::new(settings.logging.download_log_enabled);
@@ -66,7 +76,7 @@ async fn main() -> Result<()> {
     let listener = tokio::net::TcpListener::bind(&settings.server.bind_address)
         .await
         .with_context(|| format!("bind {}", settings.server.bind_address))?;
-    let app = web::router(web_store);
+    let app = web::router(web_store, status_config);
 
     println!(
         "Web UI listening on http://{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,13 +42,21 @@ async fn main() -> Result<()> {
     let web_store = download_store.clone();
     let status_config = web::StatusConfig {
         version: env!("CARGO_PKG_VERSION"),
-        lidarr_url: settings.lidarr.url.clone(),
+        data_dir: settings.data_dir.to_string_lossy().into_owned(),
         check_frequency_seconds: settings.check_frequency_seconds,
+        download_log_enabled: settings.logging.download_log_enabled,
+        lidarr_url: settings.lidarr.url.clone(),
         manual_import_enabled: settings.lidarr.manual_import_enabled,
         musicbrainz_enabled: settings.musicbrainz.disc_lookup_enabled,
+        musicbrainz_base_url: settings.musicbrainz.base_url.clone(),
+        musicbrainz_trust_disc_lookup: settings.musicbrainz.trust_disc_lookup,
+        musicbrainz_add_missing_release_group: settings.musicbrainz.add_missing_release_group_enabled,
         gnudb_enabled: settings.gnudb.disc_lookup_enabled,
+        gnudb_server: settings.gnudb.server.clone(),
         cue_strict: settings.cue.strict,
-        download_log_enabled: settings.logging.download_log_enabled,
+        shnsplit_path: settings.shnsplit.path.to_string_lossy().into_owned(),
+        shnsplit_overwrite: settings.shnsplit.overwrite,
+        shnsplit_format: settings.shnsplit.format.clone(),
     };
     let cue_scanner = FilesystemCueScanner::new();
     let cue_input_inspector = FilesystemCueInputInspector::new();


### PR DESCRIPTION
## Summary
- Add a `/status` page showing app configuration and download counts.
- Add a `DownloadStats` read-store port with a SQLite implementation.
- Wire status configuration into the web router from runtime settings.

## Validation
- `cargo clippy`
- `cargo fmt -- --check`
- `cargo fix --allow-dirty --allow-staged`
- `cargo test adapters::web`
- `cargo test sqlite_download_store`
- `cargo test` fails in 4 existing `adapters::shnsplit_splitter` tests reporting no generated tracks detected.